### PR TITLE
Add __enter__ method

### DIFF
--- a/samsungtvws/remote.py
+++ b/samsungtvws/remote.py
@@ -43,6 +43,9 @@ class SamsungTVWS:
         self.name = name
         self.connection = None
 
+    def __enter__(self):
+        return self
+
     def __exit__(self, type, value, traceback):
         self.close()
 


### PR DESCRIPTION
This will allow the component being used inside a `with `statement.
