### PR TITLE
Fix app_list() exception

### DIFF
--- a/samsungtvws/remote.py
+++ b/samsungtvws/remote.py
@@ -243,8 +243,9 @@ class SamsungTVWS:
         })
 
         response = self._process_api_response(self.connection.recv())
-        if response.get('data') and response.get('data').get('data'):
-            return response.get('data').get('data')
+        # response = {'data': 200, 'event': 'ed.apps.launch', 'from': 'host'}
+        if response.get('data'):
+            return response.get('data')
         else:
             return response
 


### PR DESCRIPTION
Fix following issue:

```log
DEBUG:samsungtvws.remote:Get app list
Traceback (most recent call last):
  File "/tmp/te", line 30, in <module>
    apps = tv.app_list()
  File "/usr/local/lib/python3.9/site-packages/samsungtvws/remote.py", line 246, in app_list
    if response.get('data') and response.get('data').get('data'):
AttributeError: 'int' object has no attribute 'get'
```

and close #25