### PR TITLE
Fixup PR for art mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,63 @@ logging.info(info)
 
 ```
 
+## Art Mode
+
+TVs that support art mode (such as The Frame) can be controlled as follows:
+
+```
+from samsungtvws import SamsungTVWS
+tv = SamsungTVWS('192.168.xxx.xxx')
+
+# Is art mode supported?
+print (tv.art().supported())
+
+# List the art available on the device
+print(tv.art().available())
+
+# Retrieve information about the currently selected art
+print(tv.art().get_current())
+
+# Retrieve a thumbnail for a specific piece of art. Returns a JPEG.
+thumbnail = tv.art().get_thumbnail('SAM-F0206')
+
+# Set a piece of art
+tv.art().set('SAM-F0206')
+
+# Set a piece of art, but don't immediately show it if not in art mode
+tv.art().set('SAM-F0201', show=False)
+
+# Determine whether the TV is currently in art mode
+print(tv.art().get_artmode())
+
+# Switch art mode on or off
+tv.art().set_artmode(True)
+tv.art().set_artmode(False)
+
+# Upload a picture
+file = open("test.png", "rb")
+data = file.read()
+tv.art().upload(data)
+
+# If uploading a JPEG
+tv.art().upload(data, filetype='JPEG')
+
+# To set the matte to modern and apricot color
+tv.art().upload(data, matte='modern_apricot')
+
+# Delete an uploaded item
+tv.art().delete("MY-F0020")
+
+# Delete multiple uploaded items
+tv.art().delete_list(["MY-F0020", "MY-F0021"])
+
+# List available photo filters
+print(tv.art().get_photo_filter_list())
+
+# Apply a filter to a specific piece of art
+tv.art().set_photo_filter('SAM-F0206', 'ink')
+```
+
 ## Supported TVs
 
 List of support TV models. https://developer.samsung.com/smarttv/develop/extension-libraries/smart-view-sdk/supported-device/supported-tvs.html

--- a/README.md
+++ b/README.md
@@ -93,29 +93,43 @@ logging.info(info)
 TVs that support art mode (such as The Frame) can be controlled as follows:
 
 ```python
+import sys
+import logging
+
+sys.path.append('../')
+
 from samsungtvws import SamsungTVWS
+
+# Increase debug level
+logging.basicConfig(level=logging.INFO)
+
+# Normal constructor
 tv = SamsungTVWS('192.168.xxx.xxx')
 
 # Is art mode supported?
-print (tv.art().supported())
+info = tv.art().supported()
+logging.info(info)
 
 # List the art available on the device
-print(tv.art().available())
+info = tv.art().available()
+logging.info(info)
 
 # Retrieve information about the currently selected art
-print(tv.art().get_current())
+info = tv.art().get_current()
+logging.info(info)
 
 # Retrieve a thumbnail for a specific piece of art. Returns a JPEG.
 thumbnail = tv.art().get_thumbnail('SAM-F0206')
 
 # Set a piece of art
-tv.art().set('SAM-F0206')
+tv.art().select_image('SAM-F0206')
 
 # Set a piece of art, but don't immediately show it if not in art mode
-tv.art().set('SAM-F0201', show=False)
+tv.art().select_image('SAM-F0201', show=False)
 
 # Determine whether the TV is currently in art mode
-print(tv.art().get_artmode())
+info = tv.art().get_artmode()
+logging.info(info)
 
 # Switch art mode on or off
 tv.art().set_artmode(True)
@@ -127,7 +141,7 @@ data = file.read()
 tv.art().upload(data)
 
 # If uploading a JPEG
-tv.art().upload(data, filetype='JPEG')
+tv.art().upload(data, file_type='JPEG')
 
 # To set the matte to modern and apricot color
 tv.art().upload(data, matte='modern_apricot')
@@ -139,7 +153,8 @@ tv.art().delete('MY-F0020')
 tv.art().delete_list(['MY-F0020', 'MY-F0021'])
 
 # List available photo filters
-print(tv.art().get_photo_filter_list())
+info = tv.art().get_photo_filter_list()
+logging.info(info)
 
 # Apply a filter to a specific piece of art
 tv.art().set_photo_filter('SAM-F0206', 'ink')

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <img src="https://user-images.githubusercontent.com/5860071/47255992-611d9b00-d481-11e8-965d-d9816f254be2.png" width="300px" border="0" />
     <br/>
     <a href="https://github.com/xchwarze/samsung-tv-ws-api/releases/latest">
-        <img src="https://img.shields.io/badge/version-1.6.0-brightgreen.svg?style=flat-square" alt="Version">
+        <img src="https://img.shields.io/badge/version-1.7.0-brightgreen.svg?style=flat-square" alt="Version">
     </a>
     Samsung Smart TV WS API wrapper
 </p>
@@ -92,7 +92,7 @@ logging.info(info)
 
 TVs that support art mode (such as The Frame) can be controlled as follows:
 
-```
+```python
 from samsungtvws import SamsungTVWS
 tv = SamsungTVWS('192.168.xxx.xxx')
 
@@ -122,7 +122,7 @@ tv.art().set_artmode(True)
 tv.art().set_artmode(False)
 
 # Upload a picture
-file = open("test.png", "rb")
+file = open('test.png', 'rb')
 data = file.read()
 tv.art().upload(data)
 
@@ -133,10 +133,10 @@ tv.art().upload(data, filetype='JPEG')
 tv.art().upload(data, matte='modern_apricot')
 
 # Delete an uploaded item
-tv.art().delete("MY-F0020")
+tv.art().delete('MY-F0020')
 
 # Delete multiple uploaded items
-tv.art().delete_list(["MY-F0020", "MY-F0021"])
+tv.art().delete_list(['MY-F0020', 'MY-F0021'])
 
 # List available photo filters
 print(tv.art().get_photo_filter_list())
@@ -161,4 +161,4 @@ For complete list https://developer.samsung.com/smarttv/develop/specifications/t
 
 ## License
 
-MIT
+GPL-2.0

--- a/samsungtvws/art.py
+++ b/samsungtvws/art.py
@@ -1,0 +1,233 @@
+"""
+SamsungTVWS - Samsung Smart TV WS API wrapper
+
+Copyright 2021 Matthew Garrett <mjg59@srcf.ucam.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+"""
+
+import json
+import random
+import requests
+import socket
+import uuid
+
+from datetime import datetime
+
+class SamsungTVArt:
+    def __init__(self, remote):
+        self.remote = remote
+        self._art_uuid = uuid.uuid4()
+
+    def supported(self):
+        data =  self.remote.rest_device_info()
+        device = data.get('device')
+        if device:
+            support = device.get('FrameTVSupport')
+        else:
+            support = None
+
+        if support == 'true':
+            return True
+        return False
+
+    def _send_art_request(self, data, response=False):
+        data['id'] = str(self._art_uuid)
+        self.remote._art_ws_send({
+            'method': 'ms.channel.emit',
+            'params': {
+                'event': 'art_app_request',
+                'to': 'host',
+                'data': json.dumps(data)
+            }
+        })
+
+        if response == True:
+            response = self.remote._process_api_response(self.remote.art_connection.recv())
+            return response
+
+    def get_api_version(self):
+        data = {
+            'request': 'get_api_version'
+        }
+
+        response = self._send_art_request(data, response=True)
+        data = json.loads(response['data'])
+        return data['version']
+
+    def get_device_info(self):
+        data = {
+            'request': 'get_device_info'
+        }
+
+        response = self._send_art_request(data, response=True)
+        data = json.loads(response['data'])
+        return data
+
+    def available(self, category=None):
+        data = {
+            'request': 'get_content_list',
+            'category': category
+        }
+
+        response = self._send_art_request(data, response=True)
+        data = json.loads(response['data'])
+        content_list = json.loads(data['content_list'])
+        return content_list
+
+    def get_current(self):
+        data = {
+            'request': 'get_current_artwork',
+        }
+
+        response = self._send_art_request(data, response=True)
+        data = json.loads(response['data'])
+        return data
+
+    def get_thumbnail(self, art):
+        data = {
+            'request': 'get_thumbnail',
+            'content_id': art,
+            'conn_info': {
+                'd2d_mode': 'socket',
+                'connection_id': '1616911254067',
+                'id': str(self._art_uuid)
+            }
+        }
+
+        response = self._send_art_request(data, response=True)
+        data = json.loads(response['data'])
+        conn_info = json.loads(data['conn_info'])
+        ip = conn_info['ip']
+        port = int(conn_info['port'])
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect((ip, port))
+        header_len = int.from_bytes(s.recv(4), 'big')
+        header = json.loads(s.recv(header_len))
+        data = s.recv(int(header['fileLength']))
+        return data
+
+    def upload(self, art, matte='shadowbox_polar', date=None, filetype='PNG'):
+        if date == None:
+            now = datetime.now()
+            date = now.strftime("%Y:%m:%d %H:%M:%S")
+        connection_id = random.randrange(4*1024*1024*1024)
+        data = {
+            'request': 'send_image',
+            'file_type': filetype,
+            'conn_info': {
+                'd2d_mode': 'socket',
+                'connection_id': connection_id,
+                'id': str(self._art_uuid),
+            },
+            'image_date': date,
+            'matte_id': matte,
+            'file_size': len(art)
+        }
+        
+        response = self._send_art_request(data, response=True)
+        data = json.loads(response['data'])
+        conn_info = json.loads(data['conn_info'])
+        ip = conn_info['ip']
+        port = int(conn_info['port'])
+        key = conn_info['key']
+        header_filetype = 'png'
+        if filetype == 'JPEG':
+            header_filetype = 'jpg'
+
+        header = {
+            'num': 0,
+            'total': 1,
+            'fileLength': len(art),
+            'fileName': 'dummy',
+            'fileType': header_filetype,
+            'secKey': key,
+            'version': '0.0.1'
+        }
+        header_string = json.dumps(header)
+        header_len = len(header_string).to_bytes(4, 'big')
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect((ip, port))
+        s.send(header_len)
+        s.send(header_string.encode('ascii'))
+        s.send(art)
+        response = self.remote._process_api_response(self.remote.art_connection.recv())
+        data = json.loads(response['data'])
+        return data['content_id']
+
+    def delete(self, art):
+        self.delete_list([art])
+
+    def delete_list(self, art):
+        artlist = []
+        for entry in art:
+            artlist.append({'content_id': entry})
+        data = {
+            'request': 'delete_image_list',
+            'content_id_list': artlist
+        }
+        self._send_art_request(data, response=True)
+
+    def set(self, art, category=None, show=True):
+        data = {
+            'request': 'select_image',
+            'category_id': category,
+            'content_id': art,
+            'show': show,
+        }
+
+        self._send_art_request(data)
+
+    def get_artmode(self):
+        data = {
+            'request': 'get_artmode_status',
+        }
+
+        response = self._send_art_request(data, response=True)
+        data = json.loads(response['data'])
+        return data['value']
+
+    def set_artmode(self, mode):
+        data = {
+            'request': 'set_artmode_status',
+            'value': mode,
+        }
+
+        self._send_art_request(data)
+
+    def get_photo_filter_list(self):
+        data = {
+            'request': 'get_photo_filter_list'
+        }
+
+        response = self._send_art_request(data, response=True)
+        data = json.loads(response['data'])
+        filter_list = json.loads(data['filter_list'])
+        return filter_list
+
+    def set_photo_filter(self, art, filter_id):
+        data = {
+            'request': 'set_photo_filter',
+            'content_id': art,
+            'filter_id': filter_id
+        }
+
+        self._send_art_request(data)
+

--- a/samsungtvws/art.py
+++ b/samsungtvws/art.py
@@ -39,7 +39,7 @@ class SamsungTVArt:
 
     def _art_ws_send(self, command):
         if self.art_connection is None:
-            self.art_connection = self.open('com.samsung.art-app')
+            self.art_connection = self.remote.open('com.samsung.art-app')
             self.art_connection.recv()
 
         payload = json.dumps(command)

--- a/samsungtvws/helper.py
+++ b/samsungtvws/helper.py
@@ -1,0 +1,21 @@
+import base64
+import json
+import logging
+from . import exceptions
+
+_LOGGING = logging.getLogger(__name__)
+
+
+def serialize_string(string):
+    if isinstance(string, str):
+        string = str.encode(string)
+
+    return base64.b64encode(string).decode('utf-8')
+
+
+def process_api_response(response):
+    try:
+        return json.loads(response)
+    except json.JSONDecodeError:
+        _LOGGING.debug('Failed to parse response from TV. response text: %s', response)
+        raise exceptions.ResponseError('Failed to parse response from TV. Maybe feature not supported on this model')

--- a/samsungtvws/remote.py
+++ b/samsungtvws/remote.py
@@ -19,7 +19,6 @@ Copyright (C) 2019 Xchwarze
     Boston, MA  02110-1335  USA
 
 """
-import base64
 import json
 import logging
 import time
@@ -29,13 +28,14 @@ import requests
 from . import art
 from . import exceptions
 from . import shortcuts
+from . import helper
 
 _LOGGING = logging.getLogger(__name__)
 
 
 class SamsungTVWS:
-    _URL_FORMAT = 'ws://{host}:{port}/api/v2/channels/{endpoint}?name={name}'
-    _SSL_URL_FORMAT = 'wss://{host}:{port}/api/v2/channels/{endpoint}?name={name}&token={token}'
+    _URL_FORMAT = 'ws://{host}:{port}/api/v2/channels/{app}?name={name}'
+    _SSL_URL_FORMAT = 'wss://{host}:{port}/api/v2/channels/{app}?name={name}&token={token}'
     _REST_URL_FORMAT = '{protocol}://{host}:{port}/api/v2/{route}'
 
     def __init__(self, host, token=None, token_file=None, port=8001, timeout=None, key_press_delay=1,
@@ -48,7 +48,6 @@ class SamsungTVWS:
         self.key_press_delay = key_press_delay
         self.name = name
         self.connection = None
-        self.art_connection = None
 
     def __enter__(self):
         return self
@@ -56,21 +55,15 @@ class SamsungTVWS:
     def __exit__(self, type, value, traceback):
         self.close()
 
-    def _serialize_string(self, string):
-        if isinstance(string, str):
-            string = str.encode(string)
-
-        return base64.b64encode(string).decode('utf-8')
-
     def _is_ssl_connection(self):
         return self.port == 8002
 
-    def _format_websocket_url(self, endpoint):
+    def _format_websocket_url(self, app):
         params = {
             'host': self.host,
             'port': self.port,
-            'endpoint': endpoint,
-            'name': self._serialize_string(self.name),
+            'app': app,
+            'name': helper.serialize_string(self.name),
             'token': self._get_token(),
         }
 
@@ -110,21 +103,13 @@ class SamsungTVWS:
 
     def _ws_send(self, command, key_press_delay=None):
         if self.connection is None:
-            self.connection = self.open("samsung.remote.control")
+            self.connection = self.open('samsung.remote.control')
 
         payload = json.dumps(command)
         self.connection.send(payload)
 
         delay = self.key_press_delay if key_press_delay is None else key_press_delay
         time.sleep(delay)
-
-    def _art_ws_send(self, command):
-        if self.art_connection is None:
-            self.art_connection = self.open("com.samsung.art-app")
-            self.art_connection.recv()
-
-        payload = json.dumps(command)
-        self.art_connection.send(payload)
 
     def _rest_request(self, target, method='GET'):
         url = self._format_rest_url(target)
@@ -139,13 +124,6 @@ class SamsungTVWS:
                 return requests.get(url, timeout=self.timeout, verify=False)
         except requests.ConnectionError:
             raise exceptions.HttpApiError('TV unreachable or feature not supported on this model.')
-
-    def _process_api_response(self, response):
-        try:
-            return json.loads(response)
-        except json.JSONDecodeError:
-            _LOGGING.debug('Failed to parse response from TV. response text: %s', response)
-            raise exceptions.ResponseError('Failed to parse response from TV. Maybe feature not supported on this model')
 
     def open(self, endpoint):
         url = self._format_websocket_url(endpoint)
@@ -163,7 +141,7 @@ class SamsungTVWS:
             connection='Connection: Upgrade'
         )
 
-        response = self._process_api_response(connection.recv())
+        response = helper.process_api_response(connection.recv())
         if response.get('data') and response.get('data').get('token'):
             token = response.get('data').get('token')
             _LOGGING.debug('Got token %s', token)
@@ -172,6 +150,7 @@ class SamsungTVWS:
         if response['event'] != 'ms.channel.connect':
             self.close()
             raise exceptions.ConnectionFailure(response)
+
         return connection
 
     def close(self):
@@ -254,37 +233,41 @@ class SamsungTVWS:
             }
         })
 
-        response = self._process_api_response(self.connection.recv())
-        # response = {'data': 200, 'event': 'ed.apps.launch', 'from': 'host'}
-        if response.get('data'):
-            return response.get('data')
+        response = helper.process_api_response(self.connection.recv())
+        if response.get('data') and response.get('data').get('data'):
+            return response.get('data').get('data')
         else:
             return response
 
     def rest_device_info(self):
         _LOGGING.debug('Get device info via rest api')
         response = self._rest_request('')
-        return self._process_api_response(response.text)
+
+        return helper.process_api_response(response.text)
 
     def rest_app_status(self, app_id):
         _LOGGING.debug('Get app %s status via rest api', app_id)
         response = self._rest_request('applications/' + app_id)
-        return self._process_api_response(response.text)
+
+        return helper.process_api_response(response.text)
 
     def rest_app_run(self, app_id):
         _LOGGING.debug('Run app %s via rest api', app_id)
         response = self._rest_request('applications/' + app_id, 'POST')
-        return self._process_api_response(response.text)
+
+        return helper.process_api_response(response.text)
 
     def rest_app_close(self, app_id):
         _LOGGING.debug('Close app %s via rest api', app_id)
         response = self._rest_request('applications/' + app_id, 'DELETE')
-        return self._process_api_response(response.text)
+
+        return helper.process_api_response(response.text)
 
     def rest_app_install(self, app_id):
         _LOGGING.debug('Install app %s via rest api', app_id)
         response = self._rest_request('applications/' + app_id, 'PUT')
-        return self._process_api_response(response.text)
+
+        return helper.process_api_response(response.text)
 
     def shortcuts(self):
         return shortcuts.SamsungTVShortcuts(self)

--- a/samsungtvws/remote.py
+++ b/samsungtvws/remote.py
@@ -26,6 +26,7 @@ import time
 import ssl
 import websocket
 import requests
+from . import art
 from . import exceptions
 from . import shortcuts
 
@@ -47,6 +48,7 @@ class SamsungTVWS:
         self.key_press_delay = key_press_delay
         self.name = name
         self.connection = None
+        self.art_connection = None
 
     def __enter__(self):
         return self
@@ -115,6 +117,14 @@ class SamsungTVWS:
 
         delay = self.key_press_delay if key_press_delay is None else key_press_delay
         time.sleep(delay)
+
+    def _art_ws_send(self, command):
+        if self.art_connection is None:
+            self.art_connection = self.open("com.samsung.art-app")
+            self.art_connection.recv()
+
+        payload = json.dumps(command)
+        self.art_connection.send(payload)
 
     def _rest_request(self, target, method='GET'):
         url = self._format_rest_url(target)
@@ -278,3 +288,6 @@ class SamsungTVWS:
 
     def shortcuts(self):
         return shortcuts.SamsungTVShortcuts(self)
+
+    def art(self):
+        return art.SamsungTVArt(self)


### PR DESCRIPTION
1) I fixed the connection issue
2) I rebased from upstream

I tested this with my 65" Frame - works perfect!

```
>>> tv = SamsungTVWS(host='samsung-frame', port=8002, token_file=token_file)
>>> tv.art().supported()
/Users/brianaegge/dev/samsung-tv-ws-api/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'samsung-frame'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
True
>>> tv.art().get_current()
{'id': '20af1789-626f-48ee-82db-bce0db9899c8', 'event': 'current_artwork', 'content_id': 'SAM-S0340', 'matte_id': 'shadowbox_polar', 'portrait_matte_id': 'shadowbox_polar', 'target_client_id': '17c4cf3-95b5-4340-aa4b-f96548f124f1'}
>>> tv.art().set_artmode(True)
>>> file = open('/Users/brianaegge/Downloads/willow.jpg','rb')
>>> data = file.read()
>>> tv.art().upload(data, file_type='JPEG')
'MY_F0001'
```
