### PR TITLE
fix get_thumbnail to download entire graphic

### DIFF
--- a/samsungtvws/art.py
+++ b/samsungtvws/art.py
@@ -132,13 +132,13 @@ class SamsungTVArt:
         header_len = int.from_bytes(art_socket.recv(4), 'big')
         header = json.loads(art_socket.recv(header_len))
 
-        datalen = int(header['fileLength'])
-        data = bytearray()
-        while len(data) < datalen:
-            packet = art_socket.recv(datalen - len(data))
-            data.extend(packet)
+        thumbnail_data_len = int(header['fileLength'])
+        thumbnail_data = bytearray()
+        while len(thumbnail_data) < thumbnail_data_len:
+            packet = art_socket.recv(thumbnail_data_len - len(thumbnail_data))
+            thumbnail_data.extend(packet)
 
-        return data
+        return thumbnail_data
 
     def upload(self, file, matte='shadowbox_polar', file_type='png', date=None):
         file_size = len(file)

--- a/samsungtvws/art.py
+++ b/samsungtvws/art.py
@@ -132,7 +132,13 @@ class SamsungTVArt:
         header_len = int.from_bytes(art_socket.recv(4), 'big')
         header = json.loads(art_socket.recv(header_len))
 
-        return art_socket.recv(int(header['fileLength']))
+        datalen = int(header['fileLength'])
+        data = bytearray()
+        while len(data) < datalen:
+            packet = art_socket.recv(datalen - len(data))
+            data.extend(packet)
+
+        return data
 
     def upload(self, file, matte='shadowbox_polar', file_type='png', date=None):
         file_size = len(file)


### PR DESCRIPTION
This is my first time using GitHub, and first time writing Python, so apologies if I'm doing this wrong!

My issue was that downloading thumbnails did not retrieve all of the data from The Frame. A 59K png only received about 3K, and then stopped. So I added a while loop that keeps downloading until the socket is finished sending data (e.g. header['fileLength'])

This was my test code that was failing to download the entire png:
thumbnail = tv.art().get_thumbnail('MY_F0011')
file = open('MY_F0011.png', 'wb')
data = file.write(thumbnail)
file.close()