### PR TITLE
Adjust isort settings to match black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,16 @@
+[tool.isort]
+# https://github.com/PyCQA/isort/wiki/isort-Settings
+profile = "black"
+force_sort_within_sections = true
+known_first_party = [
+    "samsungtvws",
+    "tests",
+]
+forced_separate = [
+    "tests",
+]
+combine_as_imports = true
+
 [tool.mypy]
 python_version = "3.7"
 

--- a/samsungtvws/art.py
+++ b/samsungtvws/art.py
@@ -20,12 +20,12 @@ Copyright (C) 2021 Matthew Garrett <mjg59@srcf.ucam.org>
     Boston, MA  02110-1335  USA
 
 """
+from datetime import datetime
 import json
 import logging
 import random
 import socket
 import uuid
-from datetime import datetime
 
 from . import helper
 from .connection import SamsungTVWSConnection


### PR DESCRIPTION
This will ensure that black and isort do not conflict.
The others align the settings with HA.