### PR TITLE
Add full type hints to async code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,8 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.931'
+    rev: v0.931
     hooks:
       - id: mypy
         additional_dependencies: [types-requests==2.27.11]
+        exclude: setup|docs/|example/|tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,16 @@ exclude = [
 [[tool.mypy.overrides]]
 module = 'websocket.*'
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = [
+    'samsungtvws.art',
+    'samsungtvws.connection',
+    'samsungtvws.helper',
+    'samsungtvws.remote',
+    'samsungtvws.rest',
+    'samsungtvws.shortcuts',
+]
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,9 @@ module = [
 disallow_untyped_calls = false
 disallow_untyped_defs = false
 
+[[tool.mypy.overrides]]
+module = [
+    'samsungtvws.async_connection',
+    'samsungtvws.async_rest',
+]
+disallow_untyped_calls = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,30 @@
 [tool.mypy]
-python_version = "3.7"
+python_version = "3.6"
+check_untyped_defs = true
+disallow_any_generics = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+no_implicit_reexport = true
+pretty = true
+show_column_numbers = true
+show_error_codes = true
+show_error_context = true
+strict_equality = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unreachable = true
+warn_unused_configs = true
+warn_unused_ignores = true
+exclude = [
+    '^docs',
+    '^example',
+    '^setup',
+    '^tests'
+]
 
 [[tool.mypy.overrides]]
 module = 'websocket.*'

--- a/samsungtvws/art.py
+++ b/samsungtvws/art.py
@@ -82,6 +82,7 @@ class SamsungTVArt(SamsungTVWSConnection):
             }
         )
 
+        assert self.art_connection
         if response:
             return helper.process_api_response(self.art_connection.recv())
 
@@ -203,6 +204,7 @@ class SamsungTVArt(SamsungTVWSConnection):
         art_socket.send(header.encode("ascii"))
         art_socket.send(file)
 
+        assert self.art_connection
         response = helper.process_api_response(self.art_connection.recv())
         data = json.loads(response["data"])
 

--- a/samsungtvws/async_rest.py
+++ b/samsungtvws/async_rest.py
@@ -20,6 +20,7 @@ Copyright (C) 2019 Xchwarze
 
 """
 import logging
+from typing import Any, Dict, Union
 
 import aiohttp
 
@@ -31,12 +32,12 @@ _LOGGING = logging.getLogger(__name__)
 class SamsungTVAsyncRest(connection.SamsungTVWSBaseConnection):
     def __init__(
         self,
-        host,
+        host: str,
         *,
         session: aiohttp.ClientSession,
-        port=8001,
-        timeout=None,
-    ):
+        port: int = 8001,
+        timeout: Union[float, None] = None,
+    ) -> None:
         super().__init__(
             host,
             endpoint=None,
@@ -45,7 +46,7 @@ class SamsungTVAsyncRest(connection.SamsungTVWSBaseConnection):
         )
         self.session = session
 
-    async def _rest_request(self, target, method="GET"):
+    async def _rest_request(self, target: str, method: str = "GET") -> Dict[str, Any]:
         url = self._format_rest_url(target)
         try:
             if method == "POST":
@@ -59,28 +60,28 @@ class SamsungTVAsyncRest(connection.SamsungTVWSBaseConnection):
             else:
                 future = self.session.get(url, timeout=self.timeout, verify_ssl=False)
             async with future as resp:
-                return helper.process_api_response(await resp.text())
+                return helper.process_api_response(await resp.text())  # type: ignore[no-any-return]
         except aiohttp.ClientConnectionError:
             raise exceptions.HttpApiError(
                 "TV unreachable or feature not supported on this model."
             )
 
-    async def rest_device_info(self):
+    async def rest_device_info(self) -> Dict[str, Any]:
         _LOGGING.debug("Get device info via rest api")
         return await self._rest_request("")
 
-    async def rest_app_status(self, app_id):
+    async def rest_app_status(self, app_id: str) -> Dict[str, Any]:
         _LOGGING.debug("Get app %s status via rest api", app_id)
         return await self._rest_request("applications/" + app_id)
 
-    async def rest_app_run(self, app_id):
+    async def rest_app_run(self, app_id: str) -> Dict[str, Any]:
         _LOGGING.debug("Run app %s via rest api", app_id)
         return await self._rest_request("applications/" + app_id, "POST")
 
-    async def rest_app_close(self, app_id):
+    async def rest_app_close(self, app_id: str) -> Dict[str, Any]:
         _LOGGING.debug("Close app %s via rest api", app_id)
         return await self._rest_request("applications/" + app_id, "DELETE")
 
-    async def rest_app_install(self, app_id):
+    async def rest_app_install(self, app_id: str) -> Dict[str, Any]:
         _LOGGING.debug("Install app %s via rest api", app_id)
         return await self._rest_request("applications/" + app_id, "PUT")

--- a/samsungtvws/command.py
+++ b/samsungtvws/command.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
-
 import json
-from typing import Any
+from typing import Any, Dict
 
 
 class SamsungTVCommand:
@@ -9,7 +7,7 @@ class SamsungTVCommand:
         self.method = method
         self.params = params
 
-    def as_dict(self) -> dict[str, Any]:
+    def as_dict(self) -> Dict[str, Any]:
         return {
             "method": self.method,
             "params": self.params,

--- a/samsungtvws/remote.py
+++ b/samsungtvws/remote.py
@@ -68,7 +68,7 @@ class ChannelEmitCommand(SamsungTVCommand):
 
 class SendRemoteKey(RemoteControlCommand):
     @staticmethod
-    def click(key: str):
+    def click(key):
         return SendRemoteKey(
             {
                 "Cmd": "Click",
@@ -256,6 +256,7 @@ class SamsungTVWS(connection.SamsungTVWSConnection):
         _LOGGING.debug("Get app list")
         self._ws_send(ChannelEmitCommand.get_installed_app())
 
+        assert self.connection
         response = helper.process_api_response(self.connection.recv())
         if response.get("data"):
             data = response["data"]


### PR DESCRIPTION
Add full type hints to async code, and enable strict typing with:
- 3.6 compatibility
- Only include samsungtvws (exclude: setup|docs/|example/|tests/)
- Allow untyped calls until everything is typed
- Allow untyped defs in the legacy code (not in the new async code)