### PR TITLE
Add support for encrypted (v1) API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,13 @@ requests>=2.21.0
 websockets>=10.2
 aiohttp>=3.8.1
 
+# encrypted
+cryptography>=35.0.0
+
 # dev
 black>=22.1
 mypy>=0.931
 pre-commit>=2.17
 pytest>=6.2.5
 pytest-asyncio>=0.18.2
+aioresponses>=0.7.3

--- a/samsungtvws/encrypted/__init__.py
+++ b/samsungtvws/encrypted/__init__.py
@@ -1,0 +1,1 @@
+"""API for the encrypted websocket API"""

--- a/samsungtvws/encrypted/authenticator.py
+++ b/samsungtvws/encrypted/authenticator.py
@@ -1,0 +1,322 @@
+"""SamsungTV Encrypted."""
+import hashlib
+import logging
+import re
+import struct
+from typing import Any, Dict, Optional
+
+import aiohttp
+from cryptography.hazmat.primitives.ciphers import (
+    Cipher,
+    CipherContext,
+    algorithms,
+    modes,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+BLOCK_SIZE = 16
+SHA_DIGEST_LENGTH = 20
+
+_PUBLIC_KEY = "2cb12bb2cbf7cec713c0fff7b59ae68a96784ae517f41d259a45d20556177c0ffe951ca60ec03a990c9412619d1bee30adc7773088c5721664cffcedacf6d251cb4b76e2fd7aef09b3ae9f9496ac8d94ed2b262eee37291c8b237e880cc7c021fb1be0881f3d0bffa4234d3b8e6a61530c00473ce169c025f47fcc001d9b8051"
+_PRIVATE_KEY = "2fd6334713816fae018cdee4656c5033a8d6b00e8eaea07b3624999242e96247112dcd019c4191f4643c3ce1605002b2e506e7f1d1ef8d9b8044e46d37c0d5263216a87cd783aa185490436c4a0cb2c524e15bc1bfeae703bcbc4b74a0540202e8d79cadaae85c6f9c218bc1107d1f5b4b9bd87160e782f4e436eeb17485ab4d"
+_WB_KEY = "abbb120c09e7114243d1fa0102163b27"
+_TRANS_KEY = "6c9474469ddf7578f3e5ad8a4c703d99"
+_PRIME = "b361eb0ab01c3439f2c16ffda7b05e3e320701ebee3e249123c3586765fd5bf6c1dfa88bb6bb5da3fde74737cd88b6a26c5ca31d81d18e3515533d08df619317063224cf0943a2f29a5fe60c1c31ddf28334ed76a6478a1122fb24c4a94c8711617ddfe90cf02e643cd82d4748d6d4a7ca2f47d88563aa2baf6482e124acd7dd"
+
+
+def _encrypt_parameter_data_with_aes(data: bytes) -> bytes:
+    iv = b"\x00" * BLOCK_SIZE
+    output = b""
+    for num in range(0, 128, 16):
+        cipher = Cipher(algorithms.AES(bytes.fromhex(_WB_KEY)), modes.CBC(iv))
+        encryptor: CipherContext = cipher.encryptor()
+        output += encryptor.update(data[num : num + 16]) + encryptor.finalize()
+    return output
+
+
+def _decrypt_parameter_data_with_aes(data: bytes) -> bytes:
+    iv = b"\x00" * BLOCK_SIZE
+    output = b""
+    for num in range(0, 128, 16):
+        cipher = Cipher(algorithms.AES(bytes.fromhex(_WB_KEY)), modes.CBC(iv))
+        decryptor: CipherContext = cipher.decryptor()
+        output += decryptor.update(data[num : num + 16]) + decryptor.finalize()
+    return output
+
+
+def _apply_samy_go_key_transform(data: bytes) -> bytes:
+    cipher = Cipher(algorithms.AES(bytes.fromhex(_TRANS_KEY)), modes.ECB())
+    encryptor: CipherContext = cipher.encryptor()
+    return encryptor.update(data) + encryptor.finalize()  # type:ignore[no-any-return]
+
+
+def _generate_server_hello(userId: str, pin: str) -> Dict[str, bytes]:
+    sha1 = hashlib.sha1()
+    sha1.update(pin.encode("utf-8"))
+    pinHash = sha1.digest()
+    aes_key = pinHash[:16]
+    LOGGER.debug("AES key: %s", aes_key.hex())
+    iv = b"\x00" * BLOCK_SIZE
+    cipher = Cipher(algorithms.AES(aes_key), modes.CBC(iv))
+    encryptor: CipherContext = cipher.encryptor()
+    encrypted = encryptor.update(bytes.fromhex(_PUBLIC_KEY)) + encryptor.finalize()
+    LOGGER.debug("AES encrypted: %s", encrypted.hex())
+    swapped = _encrypt_parameter_data_with_aes(encrypted)
+    LOGGER.debug("AES swapped: %s", swapped.hex())
+    data = struct.pack(">I", len(userId)) + userId.encode("utf-8") + swapped
+    LOGGER.debug("data buffer: %s", data.hex().upper())
+    sha1 = hashlib.sha1()
+    sha1.update(data)
+    dataHash = sha1.digest()
+    LOGGER.debug("hash: %s", dataHash.hex())
+    serverHello = (
+        b"\x01\x02"
+        + b"\x00" * 5
+        + struct.pack(">I", len(userId) + 132)
+        + data
+        + b"\x00" * 5
+    )
+    return {"serverHello": serverHello, "hash": dataHash, "AES_key": aes_key}
+
+
+def _parse_client_hello(
+    clientHello: str, dataHash: bytes, aesKey: bytes, gUserId: str
+) -> Optional[Dict[str, bytes]]:
+    LOGGER.debug("hello: %s", clientHello)
+    USER_ID_POS = 15
+    USER_ID_LEN_POS = 11
+    GX_SIZE = 0x80
+    data = bytes.fromhex(clientHello)
+    # firstLen = struct.unpack(">I", data[7:11])[0]
+    userIdLen = struct.unpack(">I", data[11:15])[0]
+    # destLen = userIdLen + 132 + SHA_DIGEST_LENGTH  # Always equals firstLen????:)
+    thirdLen = userIdLen + 132
+    LOGGER.debug("thirdLen: %s", str(thirdLen))
+    dest = data[USER_ID_LEN_POS : thirdLen + USER_ID_LEN_POS] + dataHash
+    LOGGER.debug("dest: %s", dest.hex())
+    userId = data[USER_ID_POS : userIdLen + USER_ID_POS]
+    LOGGER.debug("userId: %s", userId.decode("utf-8"))
+    pEncWBGx = data[USER_ID_POS + userIdLen : GX_SIZE + USER_ID_POS + userIdLen]
+    LOGGER.debug("pEncWBGx: %s", pEncWBGx.hex())
+    pEncGx = _decrypt_parameter_data_with_aes(pEncWBGx)
+    LOGGER.debug("pEncGx: %s", pEncGx.hex())
+    iv = b"\x00" * BLOCK_SIZE
+    cipher = Cipher(algorithms.AES(aesKey), modes.CBC(iv))
+    decryptor: CipherContext = cipher.decryptor()
+    pGx = decryptor.update(pEncGx) + decryptor.finalize()
+    LOGGER.debug("pGx: %s", pGx.hex())
+    bnPGx = int(pGx.hex(), 16)
+    bnPrime = int(_PRIME, 16)
+    bnPrivateKey = int(_PRIVATE_KEY, 16)
+    secret = bytes.fromhex(
+        hex(pow(bnPGx, bnPrivateKey, bnPrime)).rstrip("L").lstrip("0x")
+    )
+    LOGGER.debug("secret: %s", secret.hex())
+    dataHash2 = data[
+        USER_ID_POS
+        + userIdLen
+        + GX_SIZE : USER_ID_POS
+        + userIdLen
+        + GX_SIZE
+        + SHA_DIGEST_LENGTH
+    ]
+    LOGGER.debug("hash2: %s", dataHash2.hex())
+    secret2 = userId + secret
+    LOGGER.debug("secret2: %s", secret2.hex())
+    sha1 = hashlib.sha1()
+    sha1.update(secret2)
+    dataHash3 = sha1.digest()
+    LOGGER.debug("hash3: %s", dataHash3.hex())
+    if dataHash2 != dataHash3:
+        LOGGER.error("Pin error!!!")
+        return None
+    LOGGER.info("Pin OK :)\n")
+    flagPos = userIdLen + USER_ID_POS + GX_SIZE + SHA_DIGEST_LENGTH
+    if ord(data[flagPos : flagPos + 1]):
+        LOGGER.error("First flag error!!!")
+        return None
+    flagPos = userIdLen + USER_ID_POS + GX_SIZE + SHA_DIGEST_LENGTH
+    if struct.unpack(">I", data[flagPos + 1 : flagPos + 5])[0]:
+        LOGGER.error("Second flag error!!!")
+        return None
+    sha1 = hashlib.sha1()
+    sha1.update(dest)
+    dest_hash = sha1.digest()
+    LOGGER.debug("dest_hash: %s", dest_hash.hex())
+    finalBuffer = (
+        userId + gUserId.encode("utf-8") + pGx + bytes.fromhex(_PUBLIC_KEY) + secret
+    )
+    sha1 = hashlib.sha1()
+    sha1.update(finalBuffer)
+    SKPrime = sha1.digest()
+    LOGGER.debug("SKPrime: %s", SKPrime.hex())
+    sha1 = hashlib.sha1()
+    sha1.update(SKPrime + b"\x00")
+    SKPrimeHash = sha1.digest()
+    LOGGER.debug("SKPrimeHash: %s", SKPrimeHash.hex())
+    ctx = _apply_samy_go_key_transform(SKPrimeHash[:16])
+    return {"ctx": ctx, "SKPrime": SKPrime}
+
+
+def _generate_server_acknowledge(SKPrime: bytes) -> str:
+    sha1 = hashlib.sha1()
+    sha1.update(SKPrime + b"\x01")
+    SKPrimeHash = sha1.digest()
+    return "0103000000000000000014" + SKPrimeHash.hex().upper() + "0000000000"
+
+
+def _parse_client_acknowledge(clientAck: str, SKPrime: bytes) -> bool:
+    sha1 = hashlib.sha1()
+    sha1.update(SKPrime + b"\x02")
+    SKPrimeHash = sha1.digest()
+    tmpClientAck = "0104000000000000000014" + SKPrimeHash.hex().upper() + "0000000000"
+    return clientAck == tmpClientAck
+
+
+class SamsungTVEncryptedWSAsyncAuthenticator:
+    _USER_ID = "654321"
+    _APP_ID = "12345"
+    _DEVICE_ID = "7e509404-9d7c-46b4-8f6a-e2a9668ad184"
+
+    def __init__(
+        self,
+        host: str,
+        *,
+        web_session: aiohttp.ClientSession,
+        port: int = 8080,
+        timeout: Optional[float] = None,
+    ) -> None:
+        self._host = host
+        self._web_session = web_session
+        self._port = port
+        self._timeout = timeout
+        self._sk_prime: Optional[bytes] = None
+
+    def _get_full_url(self, route: str) -> str:
+        return f"http://{self._host}:{self._port}/{route}"
+
+    def _get_full_request_url(self, step: int) -> str:
+        return self._get_full_url(
+            f"ws/pairing?step={step}&app_id={self._APP_ID}&device_id={self._DEVICE_ID}"
+        )
+
+    async def _show_pin_page_on_tv(self) -> None:
+        url = self._get_full_url("ws/apps/CloudPINPage")
+        LOGGER.debug("Tx: POST %s", url)
+        async with self._web_session.post(url, data="pin4") as response:
+            LOGGER.debug("Rx: %s", await response.text())
+
+    async def _check_pin_page_on_tv(self) -> bool:
+        url = self._get_full_url("ws/apps/CloudPINPage")
+        LOGGER.debug("Tx: GET %s", url)
+        async with self._web_session.get(url) as response:
+            LOGGER.debug("Rx: %s", await response.text())
+            page = await response.text()
+        output = re.search("state>([^<>]*)</state>", page, flags=re.IGNORECASE)
+        if output is not None:
+            state = output.group(1)
+            LOGGER.info("Current PIN state: %s", state)
+            if state == "stopped":
+                return False
+        return True
+
+    async def start_pairing(self) -> None:
+        if await self._check_pin_page_on_tv():
+            LOGGER.info("Pin ON TV")
+        else:
+            LOGGER.info("Pin NOT on TV")
+            await self._show_pin_page_on_tv()
+
+    async def _first_step_of_pairing(self) -> None:
+        url = self._get_full_request_url(0) + "&type=1"
+        LOGGER.debug("Tx: GET %s", url)
+        async with self._web_session.get(url) as response:
+            LOGGER.debug("Rx: %s", await response.text())
+
+    async def _second_step_of_pairing(self, pin: str) -> Optional[Dict[str, bytes]]:
+        hello_output = _generate_server_hello(self._USER_ID, pin)
+        if not hello_output:
+            return None
+        content = (
+            '{"auth_Data":{"auth_type":"SPC","GeneratorServerHello":"'
+            + hello_output["serverHello"].hex().upper()
+            + '"}}'
+        )
+        url = self._get_full_request_url(1)
+        LOGGER.debug("Tx: POST %s", url)
+        async with self._web_session.post(url, data=content) as response:
+            LOGGER.debug("Rx: %s", await response.text())
+            response_text = await response.text()
+        output = re.search(
+            r"request_id.*?(\d).*?GeneratorClientHello.*?:.*?(\d[0-9a-zA-Z]*)",
+            response_text,
+            flags=re.IGNORECASE,
+        )
+        if output is None:
+            return None
+        # request_id = output.group(1)
+        client_hello = output.group(2)
+        # lastRequestId = int(requestId)
+        return _parse_client_hello(
+            client_hello, hello_output["hash"], hello_output["AES_key"], self._USER_ID
+        )
+
+    async def try_pin(self, pin: str) -> Optional[str]:
+        LOGGER.debug("Trying pin: '%s'", pin)
+        await self._first_step_of_pairing()
+        result = await self._second_step_of_pairing(pin)
+        if result:
+            LOGGER.info("Pin accepted :)")
+            token = result["ctx"].hex()
+            self._sk_prime = result["SKPrime"]
+            LOGGER.info("Token (ctx): %s", token)
+            return token
+
+        LOGGER.info("Pin incorrect. Please try again")
+        return None
+
+    async def _acknowledge_exchange(self) -> str:
+        assert self._sk_prime
+        server_ack_message = _generate_server_acknowledge(self._sk_prime)
+        content = (
+            '{"auth_Data":{"auth_type":"SPC","request_id":"0","ServerAckMsg":"'
+            + server_ack_message
+            + '"}}'
+        )
+        url = self._get_full_request_url(2)
+        LOGGER.debug("Tx: POST %s", url)
+        async with self._web_session.post(url, data=content) as response:
+            LOGGER.debug("Rx: %s", await response.text())
+            response_text = await response.text()
+        if "secure-mode" in response_text:
+            raise Exception("TODO: Implement handling of encryption flag!!!!")
+        output = re.search(
+            r"ClientAckMsg.*?:.*?(\d[0-9a-zA-Z]*).*?session_id.*?(\d)",
+            response_text,
+            flags=re.IGNORECASE,
+        )
+        if output is None:
+            raise Exception("Unable to get session_id and/or ClientAckMsg!!!")
+        client_ack = output.group(1)
+        assert self._sk_prime
+        if not _parse_client_acknowledge(client_ack, self._sk_prime):
+            raise Exception("Parse client ac message failed.")
+
+        session_id = output.group(2)
+        LOGGER.info("Got sessionId: %s", session_id)
+        return session_id  # type:ignore[no-any-return]
+
+    async def _close_pin_page_on_tv(self) -> None:
+        url = self._get_full_url("ws/apps/CloudPINPage/run")
+        LOGGER.debug("Tx: DELETE %s", url)
+        async with self._web_session.delete(url) as response:
+            LOGGER.debug("Rx: %s", await response.text())
+
+    async def get_session_id_and_close(self) -> str:
+        session_id = await self._acknowledge_exchange()
+        LOGGER.info("SessionID: %s", session_id)
+        await self._close_pin_page_on_tv()
+        LOGGER.info("Authorization successful :)\n")
+        return session_id

--- a/samsungtvws/encrypted/command.py
+++ b/samsungtvws/encrypted/command.py
@@ -1,0 +1,23 @@
+"""SamsungTV Encrypted."""
+import json
+from typing import Any, Dict
+
+
+class SamsungTVEncryptedCommand:
+    def __init__(self, method: str, body: Dict[str, Any]) -> None:
+        self.method = method
+        self.body = body
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "method": self.method,
+            "body": self.body,
+        }
+
+    def get_payload(self) -> str:
+        return json.dumps(self.as_dict())
+
+
+class SamsungTVEncryptedPostCommand(SamsungTVEncryptedCommand):
+    def __init__(self, body: Dict[str, Any]) -> None:
+        super().__init__("POST", body)

--- a/samsungtvws/encrypted/remote.py
+++ b/samsungtvws/encrypted/remote.py
@@ -1,0 +1,184 @@
+"""SamsungTV Encrypted."""
+import asyncio
+import contextlib
+import logging
+import time
+from types import TracebackType
+from typing import List, Optional
+
+import aiohttp
+from websockets.client import WebSocketClientProtocol, connect
+from websockets.exceptions import ConnectionClosed
+
+from ..exceptions import ConnectionFailure
+from .command import SamsungTVEncryptedCommand
+from .session import SamsungTVEncryptedSession
+
+LOGGER = logging.getLogger(__name__)
+
+
+class SendRemoteKey:
+    @staticmethod
+    def click(key: str) -> SamsungTVEncryptedCommand:
+        return SamsungTVEncryptedCommand(
+            "POST",
+            {
+                "plugin": "RemoteControl",
+                "param1": "uuid:12345",
+                "param2": "Click",
+                "param3": key,
+                "param4": False,
+                "api": "SendRemoteKey",
+                "version": "1.000",
+            },
+        )
+
+
+class SamsungTVEncryptedWSAsyncRemote:
+    _REST_URL_FORMAT = "http://{host}:{port}/{route}"
+    _URL_FORMAT = "ws://{host}:{port}/socket.io/1/websocket/{app}"
+
+    _connection: Optional[WebSocketClientProtocol]
+    _recv_loop: Optional["asyncio.Task[None]"]
+
+    def __init__(
+        self,
+        host: str,
+        *,
+        web_session: aiohttp.ClientSession,
+        token: str,
+        session_id: str,
+        port: int = 8000,
+        timeout: Optional[float] = None,
+        key_press_delay: float = 1,
+    ) -> None:
+        self._host = host
+        self._key_press_delay = key_press_delay
+        self._port = port
+        self._session: Optional[SamsungTVEncryptedSession] = None
+        if token and session_id:
+            self._session = SamsungTVEncryptedSession(token, session_id)
+        self._timeout = None if timeout == 0 else timeout
+        self._web_session = web_session
+
+        self._connection = None
+        self._recv_loop = None
+
+    async def __aenter__(self) -> "SamsungTVEncryptedWSAsyncRemote":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        await self.close()
+
+    def _format_websocket_url(self, app: str) -> str:
+        params = {
+            "host": self._host,
+            "port": self._port,
+            "app": app,
+        }
+
+        return self._URL_FORMAT.format(**params)
+
+    def _format_rest_url(self, route: str = "") -> str:
+        params = {
+            "host": self._host,
+            "port": self._port,
+            "route": route,
+        }
+
+        return self._REST_URL_FORMAT.format(**params)
+
+    async def _open(self) -> None:
+        if self._connection:
+            # someone else already created a new connection
+            return
+
+        millis = int(round(time.time() * 1000))
+        step4_url = self._format_rest_url(f"socket.io/1/?t={millis}")
+        LOGGER.debug("Tx: GET %s", step4_url)
+        async with self._web_session.get(step4_url) as response:
+            LOGGER.debug("Rx: %s", await response.text())
+            step4_response = await response.text()
+
+        url = self._format_websocket_url(step4_response.split(":")[0])
+
+        LOGGER.debug("WS url %s", url)
+        connection = await connect(url, open_timeout=self._timeout)
+        await connection.send("1::/com.samsung.companion")
+
+        self._connection = connection
+
+    async def start_listening(self) -> None:
+        """Open, and start listening."""
+        if self._connection:
+            raise ConnectionFailure("Connection already exists")
+
+        await self._open()
+        assert self._connection
+
+        self._recv_loop = asyncio.ensure_future(
+            self._do_start_listening(self._connection)
+        )
+
+    @staticmethod
+    async def _do_start_listening(
+        connection: WebSocketClientProtocol,
+    ) -> None:
+        """Do start listening."""
+        with contextlib.suppress(ConnectionClosed):
+            while True:
+                data = await connection.recv()
+                LOGGER.debug("SamsungTVEncryptedWS websocket event: %s", data)
+
+    async def send_command(
+        self,
+        command: SamsungTVEncryptedCommand,
+        key_press_delay: Optional[float] = None,
+    ) -> None:
+        await self.send_commands([command], key_press_delay)
+
+    async def send_commands(
+        self,
+        commands: List[SamsungTVEncryptedCommand],
+        key_press_delay: Optional[float] = None,
+    ) -> None:
+        assert self._session
+        if self._connection is None:
+            await self._open()
+            assert self._connection
+
+        delay = self._key_press_delay if key_press_delay is None else key_press_delay
+
+        for command in commands:
+            await self._send_command(self._connection, command, self._session, delay)
+
+    @staticmethod
+    async def _send_command(
+        connection: WebSocketClientProtocol,
+        command: SamsungTVEncryptedCommand,
+        session: SamsungTVEncryptedSession,
+        delay: float,
+    ) -> None:
+        LOGGER.debug("SamsungTVEncryptedWS websocket command: %s", command.as_dict())
+        payload = session.encrypt_command(command)
+        LOGGER.debug("SamsungTVEncryptedWS websocket command (encrypted): %s", payload)
+        await connection.send(payload)
+
+        await asyncio.sleep(delay)
+
+    async def close(self) -> None:
+        if self._connection:
+            await self._connection.close()
+            if self._recv_loop:
+                await self._recv_loop
+
+        self._connection = None
+        LOGGER.debug("Connection closed")
+
+    def is_alive(self) -> bool:
+        return self._connection is not None and not self._connection.closed

--- a/samsungtvws/encrypted/session.py
+++ b/samsungtvws/encrypted/session.py
@@ -1,0 +1,53 @@
+"""SamsungTV Encrypted."""
+import binascii
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+from .command import SamsungTVEncryptedCommand
+
+
+# Padding for the input string --not related to encryption itself.
+class _Padding:
+    _BLOCK_SIZE = 16  # Bytes
+
+    @staticmethod
+    def pad(text: str) -> str:
+        return text + (_Padding._BLOCK_SIZE - len(text) % _Padding._BLOCK_SIZE) * chr(
+            _Padding._BLOCK_SIZE - len(text) % _Padding._BLOCK_SIZE
+        )
+
+    @staticmethod
+    def unpad(text: bytes) -> str:
+        return text[: -ord(text[len(text) - 1 :])].decode()
+
+
+class SamsungTVEncryptedSession:
+    def __init__(self, token: str, session_id: str) -> None:
+        self._token = binascii.unhexlify(token)
+        self._session_id = session_id
+        self._cipher = Cipher(algorithms.AES(self._token), modes.ECB())
+
+    def _decrypt(self, enc: bytes) -> str:
+        decryptor = self._cipher.decryptor()
+        return _Padding.unpad(
+            decryptor.update(binascii.unhexlify(enc)) + decryptor.finalize()
+        )
+
+    def _encrypt(self, raw: str) -> bytes:
+        encryptor = self._cipher.encryptor()
+        return (  # type:ignore[no-any-return]
+            encryptor.update(bytes(_Padding.pad(raw), encoding="utf8"))
+            + encryptor.finalize()
+        )
+
+    def encrypt_command(self, command: SamsungTVEncryptedCommand) -> str:
+        command_bytes = self._encrypt(command.get_payload())
+
+        int_array = ",".join(list(map(str, command_bytes)))
+        return (
+            '5::/com.samsung.companion:{"name":"callCommon","args":[{"Session_Id":'
+            + self._session_id
+            + ',"body":"['
+            + int_array
+            + ']"}]}'
+        )

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     install_requires=["websocket-client>=0.57.0", "requests>=2.21.0"],
     extras_require={
         "async": ["aiohttp>=3.8.1", "websockets>=10.2"],
+        "encrypted": ["cryptography>=35.0.0"],
     },
     include_package_data=True,
     license="MIT",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 import asyncio
 from unittest.mock import Mock, patch
 
+from aioresponses import aioresponses
 import pytest
 from websockets.client import WebSocketClientProtocol
 
@@ -44,3 +45,9 @@ def get_async_connection():
     ) as connection_class:
         connection_class.return_value.set_result(connection)
         yield connection
+
+
+@pytest.fixture(name="aioresponse")
+def mock_aioresponse():
+    with aioresponses() as m:
+        yield m

--- a/tests/test_encrypted.py
+++ b/tests/test_encrypted.py
@@ -1,0 +1,135 @@
+"""SamsungTV Encrypted."""
+import binascii
+
+import aiohttp
+from aioresponses import aioresponses
+import pytest
+from yarl import URL
+
+from samsungtvws.encrypted.authenticator import SamsungTVEncryptedWSAsyncAuthenticator
+from samsungtvws.encrypted.command import SamsungTVEncryptedCommand
+from samsungtvws.encrypted.session import SamsungTVEncryptedSession
+
+TOKEN = "037739871315caef138547b03e348b72"
+SESSION_ID = "1"
+
+
+def test_simple_encrypt() -> None:
+    session = SamsungTVEncryptedSession(TOKEN, SESSION_ID)
+    message = "This is a test message"
+
+    encrypted_bytes = session._encrypt(message)
+    assert (
+        encrypted_bytes
+        == b"\xf9\xe8\x1c++:i\xb0\xd4\xc4\x12o$\x9e\x017\x9c\x9cS\x88\xd9\xbb"
+        b"\x82/\xfb\xee\x0fD\xc2\xb9\x19\x03"
+    )
+    decrypted_bytes = session._decrypt(binascii.hexlify(encrypted_bytes))
+    assert decrypted_bytes == message
+
+
+def test_command_encryption() -> None:
+    session = SamsungTVEncryptedSession(TOKEN, SESSION_ID)
+    command = SamsungTVEncryptedCommand(
+        "POST",
+        {
+            "plugin": "RemoteControl",
+            "param1": "uuid:12345",
+            "param2": "Click",
+            "param3": "KEY_POWER",
+            "param4": False,
+            "api": "SendRemoteKey",
+            "version": "1.000",
+        },
+    )
+
+    assert (
+        session.encrypt_command(command)
+        == '5::/com.samsung.companion:{"name":"callCommon","args":[{"Session_Id":1,'
+        '"body":"[36,178,255,123,141,203,175,38,44,80,238,135,196,244,171,173,168,'
+        "203,242,52,81,131,19,209,43,150,125,3,229,60,22,185,94,51,71,133,63,60,116,"
+        "56,119,181,6,91,32,218,39,71,242,208,209,160,67,81,186,70,83,138,123,99,0,"
+        "64,72,86,155,165,43,171,54,77,172,34,121,51,34,203,42,110,49,65,75,172,23,"
+        "19,54,30,190,174,55,214,124,242,118,85,209,204,245,255,56,29,199,94,185,6,"
+        "34,82,126,32,29,81,15,137,197,87,119,61,229,138,138,26,233,26,218,47,162,"
+        "132,151,47,148,22,139,193,11,253,224,235,38,228,81,172,9,73,1,119,68,22,170,"
+        "159,82,31,133,14,135,250,9,176,177,154,168,133,246,223,199,55,254,201,69,76,"
+        "5,234,89,212,194,79,28,96,94,86,240,99,19,152,34,38,237,222,8,185,142,127,"
+        '73,181]"}]}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_authenticator(aioresponse: aioresponses) -> None:
+    aioresponse.get("http://1.2.3.4:8080/ws/apps/CloudPINPage", body="")
+    aioresponse.get(
+        "http://1.2.3.4:8080/ws/pairing?step=0&app_id=12345"
+        "&device_id=7e509404-9d7c-46b4-8f6a-e2a9668ad184&type=1",
+        body="",
+    )
+    client_hello = (
+        "010100000000000000009e00000006363534333231f596d0966d"
+        "38bdf42546fb2a06ae96161680381fbca62498e82903c36da100eba0c148cc1545d"
+        "b8f976a14423d95df7cac081b3722c2720c7ecc8d746d269319d309d36e432a1e32"
+        "fea28dd7492692a71c7bf531d11a8f45ebb2a2834bb21e02e83ac7978396c03cfdd"
+        "53256df124c09fdcae1711a9aeceaa83f3b8d8b2e70dcfe709b3e807dcaa9a9787f"
+        "6a2f64475e9a70c1d80000000000"
+    )
+    aioresponse.post(
+        "http://1.2.3.4:8080/ws/pairing?step=1&app_id=12345"
+        "&device_id=7e509404-9d7c-46b4-8f6a-e2a9668ad184",
+        body="request_id.*?1.*?GeneratorClientHello.*?:.*?" + client_hello,
+    )
+    client_ack = (
+        "0104000000000000000014CF0EDA4882C5D560B584D5897A7EDDE7FABC16E80000000000"
+    )
+    aioresponse.post(
+        "http://1.2.3.4:8080/ws/pairing?step=2&app_id=12345"
+        "&device_id=7e509404-9d7c-46b4-8f6a-e2a9668ad184",
+        body="ClientAckMsg.*?:.*?" + client_ack + ".*?session_id.*?1",
+    )
+    aioresponse.delete("http://1.2.3.4:8080/ws/apps/CloudPINPage/run", body="")
+
+    authenticator = SamsungTVEncryptedWSAsyncAuthenticator(
+        "1.2.3.4", web_session=aiohttp.ClientSession()
+    )
+    await authenticator.start_pairing()
+    token = await authenticator.try_pin("0997")
+    assert token == TOKEN
+
+    session_id = await authenticator.get_session_id_and_close()
+    assert session_id == SESSION_ID
+
+    assert len(aioresponse.requests) == 5
+    print(aioresponse.requests)
+
+    request = aioresponse.requests[
+        (
+            "POST",
+            URL(
+                "http://1.2.3.4:8080/ws/pairing?app_id=12345&device_id=7e509404-9d7c-46b4-8f6a-e2a9668ad184&step=1"
+            ),
+        )
+    ]
+    assert (
+        request[0].kwargs["data"]
+        == '{"auth_Data":{"auth_type":"SPC","GeneratorServerHello":'
+        '"010200000000000000008A000000063635343332317CAF9CBDC06B666D23EBC'
+        "A615E0666FEB2B807091BF507404DDD18329CD64A91E513DC704298CCE49C4C5"
+        "656C42141A696354A7145127BCD94CDD2B0D632D87E332437F86EBE5A50A1512"
+        "F3F54C71B791A88ECBAF562FBABE2731F27D851A764CA114DBE2C2C965DF151C"
+        'FC7401920FAA04636B356B97DBE1DA3A090004F81830000000000"}}'
+    )
+    request = aioresponse.requests[
+        (
+            "POST",
+            URL(
+                "http://1.2.3.4:8080/ws/pairing?app_id=12345&device_id=7e509404-9d7c-46b4-8f6a-e2a9668ad184&step=2"
+            ),
+        )
+    ]
+    assert (
+        request[0].kwargs["data"]
+        == '{"auth_Data":{"auth_type":"SPC","request_id":"0","ServerAckMsg":'
+        '"01030000000000000000145F38EAFF0F6A6FF062CA652CD6CBAD9AF1EC62470000000000"}}'
+    )


### PR DESCRIPTION
Since the encrypted (v1) API also uses a websocket, and since the TVs also use the same REST api for the device info, does it not make sense to include it here?