### PR TITLE
Added support for listing/changing art mode mats

### DIFF
--- a/example/art_remove_mats.py
+++ b/example/art_remove_mats.py
@@ -1,7 +1,7 @@
-import sys
 import logging
+import sys
 
-sys.path.append('../')
+sys.path.append("../")
 
 from samsungtvws import SamsungTVWS
 
@@ -9,26 +9,35 @@ from samsungtvws import SamsungTVWS
 logging.basicConfig(level=logging.INFO)
 
 # Normal constructor
-tv = SamsungTVWS('192.168.xxx.xxx')
+tv = SamsungTVWS("192.168.xxx.xxx")
 
 # Set all mats to this type
-target_matte_type = 'none'
+target_matte_type = "none"
 
 # Is art mode supported?
 if not tv.art().supported():
-    logging.error('Art mode not supported')
+    logging.error("Art mode not supported")
     sys.exit(1)
 
 # List available mats for displaying art
-matte_types = [matte_type for elem in tv.art().get_matte_list() for matte_type in elem.values()]
+matte_types = [
+    matte_type for elem in tv.art().get_matte_list() for matte_type in elem.values()
+]
+
 if target_matte_type not in matte_types:
-    logging.error('Invalid matte type: {}. Supported matte types are: {}'.format(target_matte_type, matte_types))
+    logging.error(
+        "Invalid matte type: {}. Supported matte types are: {}".format(
+            target_matte_type, matte_types
+        )
+    )
     sys.exit(1)
 
 # List the art available on the device
 available_art = tv.art().available()
 
 for art in available_art:
-    if art['matte_id'] != target_matte_type:
-        logging.info("Setting matte to {} for {}".format(target_matte_type, art['content_id']))
-        tv.art().change_matte(art['content_id'], target_matte_type)
+    if art["matte_id"] != target_matte_type:
+        logging.info(
+            "Setting matte to {} for {}".format(target_matte_type, art["content_id"])
+        )
+        tv.art().change_matte(art["content_id"], target_matte_type)

--- a/example/art_remove_mats.py
+++ b/example/art_remove_mats.py
@@ -22,7 +22,7 @@ if not tv.art().supported():
 # List available mats for displaying art
 matte_types = [matte_type for elem in tv.art().get_matte_list() for matte_type in elem.values()]
 if target_matte_type not in matte_types:
-    logging.error('Invalid matte type: {}'.format(target_matte_type))
+    logging.error('Invalid matte type: {}. Supported matte types are: {}'.format(target_matte_type, matte_types))
     sys.exit(1)
 
 # List the art available on the device
@@ -30,5 +30,5 @@ available_art = tv.art().available()
 
 for art in available_art:
     if art['matte_id'] != target_matte_type:
-        logging.info("Setting matte to %s for %s", target_matte_type, art['content_id'])
+        logging.info("Setting matte to {} for {}".format(target_matte_type, art['content_id']))
         tv.art().change_matte(art['content_id'], target_matte_type)

--- a/example/art_remove_mats.py
+++ b/example/art_remove_mats.py
@@ -1,0 +1,34 @@
+import sys
+import logging
+
+sys.path.append('../')
+
+from samsungtvws import SamsungTVWS
+
+# Increase debug level
+logging.basicConfig(level=logging.INFO)
+
+# Normal constructor
+tv = SamsungTVWS('192.168.xxx.xxx')
+
+# Set all mats to this type
+target_matte_type = 'none'
+
+# Is art mode supported?
+if not tv.art().supported():
+    logging.error('Art mode not supported')
+    sys.exit(1)
+
+# List available mats for displaying art
+matte_types = [matte_type for elem in tv.art().get_matte_list() for matte_type in elem.values()]
+if target_matte_type not in matte_types:
+    logging.error('Invalid matte type: {}'.format(target_matte_type))
+    sys.exit(1)
+
+# List the art available on the device
+available_art = tv.art().available()
+
+for art in available_art:
+    if art['matte_id'] != target_matte_type:
+        logging.info("Setting matte to %s for %s", target_matte_type, art['content_id'])
+        tv.art().change_matte(art['content_id'], target_matte_type)

--- a/example/art_remove_mats.py
+++ b/example/art_remove_mats.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.append("../")
 
-from samsungtvws import SamsungTVWS
+from samsungtvws import SamsungTVWS  # noqa: E402
 
 # Increase debug level
 logging.basicConfig(level=logging.INFO)

--- a/samsungtvws/art.py
+++ b/samsungtvws/art.py
@@ -338,3 +338,22 @@ class SamsungTVArt(SamsungTVWSConnection):
                 "filter_id": filter_id,
             }
         )
+
+    def get_matte_list(self):
+        response = self._send_art_request(
+            {"request": "get_matte_list"},
+            wait_for_event=D2D_SERVICE_MESSAGE_EVENT,
+        )
+        assert response
+        data = json.loads(response["data"])
+
+        return json.loads(data["matte_type_list"])
+
+    def change_matte(self, content_id, matte_id):
+        self._send_art_request(
+            {
+                "request": "change_matte",
+                "content_id": content_id,
+                "matte_id": matte_id,
+            }
+        )

--- a/tests/test_art.py
+++ b/tests/test_art.py
@@ -92,3 +92,21 @@ def test_set_available(connection: Mock) -> None:
         connection.send.assert_called_once_with(
             '{"method": "ms.channel.emit", "params": {"event": "art_app_request", "to": "host", "data": "{\\"request\\": \\"get_content_list\\", \\"category\\": null, \\"id\\": \\"07e72228-7110-4655-aaa6-d81b5188c219\\"}"}}'
         )
+
+
+def test_change_matte(connection: Mock) -> None:
+    with patch(
+        "samsungtvws.art.uuid.uuid4",
+        return_value="07e72228-7110-4655-aaa6-d81b5188c219",
+    ):
+        connection.recv.side_effect = [
+            MS_CHANNEL_CONNECT_SAMPLE,
+            MS_CHANNEL_READY_SAMPLE,
+            D2D_SERVICE_MESSAGE_AVAILABLE_SAMPLE,
+        ]
+        tv_art = SamsungTVArt("127.0.0.1")
+        tv_art.change_matte("test", "none")
+
+        connection.send.assert_called_once_with(
+            '{"method": "ms.channel.emit", "params": {"event": "art_app_request", "to": "host", "data": "{\\"request\\": \\"change_matte\\", \\"content_id\\": \\"test\\", \\"matte_id\\": \\"none\\", \\"id\\": \\"07e72228-7110-4655-aaa6-d81b5188c219\\"}"}}'
+        )


### PR DESCRIPTION
Added support for
-  listing supported art mode mats
- setting mats on existing art
- an example script that changes mats on all existing art

Tested on 2021 Frame TVs


Reference messages from network capture:
```

{"method":"ms.channel.emit","params":{"data":"{"request":"get_matte_list","id":"72cb249b-b44b-4a05-89e5-03cfe0f78ca6"}","to":"host","event":"art_app_request"}}

--------------------

{"data":"{
  "id": "72cb249b-b44b-4a05-89e5-03cfe0f78ca6",
  "event": "matte_list",
  "matte_type_list": "[
  {
    "matte_type": "none"
  },
  {
    "matte_type": "myshelf"
  

--------------------

{"method":"ms.channel.emit","params":{"data":"{"request":"change_matte","content_id":"MY_F0517","matte_id":"none","id":"5292a036-2ab2-4d19-906b-73e4321d75ff"}","to":"host","event":"art_app_request"}}

--------------------

{"data":"{
  "id": "5292a036-2ab2-4d19-906b-73e4321d75ff",
  "event": "matte_changed",
  "matte_id": "none",
  "target_client_id": "326a44d-688-401c-89e1-b2271d27d39f"
}","event":"d2d_service_message","fro

```