### PR TITLE
Fix CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.0
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/adrienverge/yamllint.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: mypy
         additional_dependencies: [types-requests==2.27.11]
         exclude: setup|docs/|example/|tests/
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
       - id: flake8

--- a/samsungtvws/async_connection.py
+++ b/samsungtvws/async_connection.py
@@ -42,7 +42,6 @@ _LOGGING = logging.getLogger(__name__)
 
 
 class SamsungTVWSAsyncConnection(connection.SamsungTVWSBaseConnection):
-
     connection: Optional[WebSocketClientProtocol]
     _recv_loop: Optional["asyncio.Task[None]"]
 

--- a/samsungtvws/connection.py
+++ b/samsungtvws/connection.py
@@ -138,7 +138,6 @@ class SamsungTVWSBaseConnection:
 
 
 class SamsungTVWSConnection(SamsungTVWSBaseConnection):
-
     connection: Optional[websocket.WebSocket]
     _recv_loop: Optional[threading.Thread]
 


### PR DESCRIPTION
- Fix path to flake8 repository, linked to https://flake8.pycqa.org/en/latest/release-notes/4.0.0.html
- Bump isort to 5.12.0, linked to https://github.com/PyCQA/isort/issues/2077
- Fix black errors that have crept in
