### PR TITLE
Bump websockets minimum version to 13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ websocket-client>=0.57.0
 requests>=2.21.0
 
 # async
-websockets>=10.2
+websockets>=13
 aiohttp>=3.8.1
 async_timeout>=4.0.3
 

--- a/samsungtvws/async_connection.py
+++ b/samsungtvws/async_connection.py
@@ -23,7 +23,7 @@ from typing import (
     Union,
 )
 
-from websockets.client import WebSocketClientProtocol, connect
+from websockets.asyncio.client import ClientConnection, connect
 from websockets.exceptions import ConnectionClosed
 
 from . import connection, exceptions, helper
@@ -39,7 +39,7 @@ _LOGGING = logging.getLogger(__name__)
 
 
 class SamsungTVWSAsyncConnection(connection.SamsungTVWSBaseConnection):
-    connection: Optional[WebSocketClientProtocol]
+    connection: Optional[ClientConnection]
     _recv_loop: Optional["asyncio.Task[None]"]
 
     async def __aenter__(self) -> "SamsungTVWSAsyncConnection":
@@ -53,7 +53,7 @@ class SamsungTVWSAsyncConnection(connection.SamsungTVWSBaseConnection):
     ) -> None:
         await self.close()
 
-    async def open(self) -> WebSocketClientProtocol:
+    async def open(self) -> ClientConnection:
         if self.connection:
             # someone else already created a new connection
             return self.connection
@@ -104,7 +104,7 @@ class SamsungTVWSAsyncConnection(connection.SamsungTVWSBaseConnection):
     async def _do_start_listening(
         self,
         callback: Optional[Callable[[str, Any], Optional[Awaitable[None]]]],
-        connection: WebSocketClientProtocol,
+        connection: ClientConnection,
     ) -> None:
         """Do start listening."""
         with contextlib.suppress(ConnectionClosed):
@@ -146,7 +146,7 @@ class SamsungTVWSAsyncConnection(connection.SamsungTVWSBaseConnection):
         key_press_delay: Optional[float] = None,
     ) -> None:
         if isinstance(command, list):
-            _LOGGING.warn(
+            _LOGGING.warning(
                 "Using send_command to send multiple commands is deprecated, "
                 "please use send_commands."
             )
@@ -157,7 +157,7 @@ class SamsungTVWSAsyncConnection(connection.SamsungTVWSBaseConnection):
 
     @staticmethod
     async def _send_command(
-        connection: WebSocketClientProtocol,
+        connection: ClientConnection,
         command: Union[SamsungTVCommand, Dict[str, Any]],
         delay: float,
     ) -> None:

--- a/samsungtvws/encrypted/remote.py
+++ b/samsungtvws/encrypted/remote.py
@@ -8,7 +8,7 @@ from types import TracebackType
 from typing import List, Optional
 
 import aiohttp
-from websockets.client import WebSocketClientProtocol, connect
+from websockets.asyncio.client import ClientConnection, connect
 from websockets.exceptions import ConnectionClosed
 
 from ..exceptions import ConnectionFailure
@@ -39,7 +39,7 @@ class SamsungTVEncryptedWSAsyncRemote:
     REST_URL_FORMAT = "http://{host}:{port}/{route}"
     URL_FORMAT = "ws://{host}:{port}/socket.io/1/websocket/{app}"
 
-    _connection: Optional[WebSocketClientProtocol]
+    _connection: Optional[ClientConnection]
     _recv_loop: Optional["asyncio.Task[None]"]
 
     def __init__(
@@ -129,7 +129,7 @@ class SamsungTVEncryptedWSAsyncRemote:
 
     @staticmethod
     async def _do_start_listening(
-        connection: WebSocketClientProtocol,
+        connection: ClientConnection,
     ) -> None:
         """Do start listening."""
         with contextlib.suppress(ConnectionClosed):
@@ -160,7 +160,7 @@ class SamsungTVEncryptedWSAsyncRemote:
 
     @staticmethod
     async def _send_command(
-        connection: WebSocketClientProtocol,
+        connection: ClientConnection,
         command: SamsungTVEncryptedCommand,
         session: SamsungTVEncryptedSession,
         delay: float,

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=find_packages(exclude=("tests",)),
     install_requires=["websocket-client>=0.57.0", "requests>=2.21.0"],
     extras_require={
-        "async": ["aiohttp>=3.8.1", "websockets>=10.2"],
+        "async": ["aiohttp>=3.8.1", "websockets>=13"],
         "encrypted": ["cryptography>=35.0.0", "py3rijndael>=0.3.3"],
     },
     include_package_data=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 
 from aioresponses import aioresponses
 import pytest
-from websockets.client import WebSocketClientProtocol
+from websockets.asyncio.client import ClientConnection
 
 
 @pytest.fixture(autouse=True)
@@ -40,7 +40,7 @@ def override_asyncio_sleep():
 @pytest.fixture(name="async_connection")
 def get_async_connection():
     """Open a websockets connection."""
-    connection = Mock(WebSocketClientProtocol)
+    connection = Mock(ClientConnection)
     with patch(
         "samsungtvws.async_connection.connect", return_value=asyncio.Future()
     ) as connection_class:


### PR DESCRIPTION
Fixes various deprecation warnings in Home Assistant

See https://websockets.readthedocs.io/en/stable/howto/upgrade.html