### PR TITLE
Fix aiohttp DeprecationWarning for verify_ssl

### DIFF
--- a/samsungtvws/async_rest.py
+++ b/samsungtvws/async_rest.py
@@ -37,15 +37,15 @@ class SamsungTVAsyncRest(connection.SamsungTVWSBaseConnection):
         url = self._format_rest_url(target)
         try:
             if method == "POST":
-                future = self.session.post(url, timeout=self.timeout, verify_ssl=False)
+                future = self.session.post(url, timeout=self.timeout, ssl=False)
             elif method == "PUT":
-                future = self.session.put(url, timeout=self.timeout, verify_ssl=False)
+                future = self.session.put(url, timeout=self.timeout, ssl=False)
             elif method == "DELETE":
                 future = self.session.delete(
-                    url, timeout=self.timeout, verify_ssl=False
+                    url, timeout=self.timeout, ssl=False
                 )
             else:
-                future = self.session.get(url, timeout=self.timeout, verify_ssl=False)
+                future = self.session.get(url, timeout=self.timeout, ssl=False)
             async with future as resp:
                 return helper.process_api_response(await resp.text())
         except aiohttp.ClientConnectionError as err:

--- a/samsungtvws/async_rest.py
+++ b/samsungtvws/async_rest.py
@@ -41,9 +41,7 @@ class SamsungTVAsyncRest(connection.SamsungTVWSBaseConnection):
             elif method == "PUT":
                 future = self.session.put(url, timeout=self.timeout, ssl=False)
             elif method == "DELETE":
-                future = self.session.delete(
-                    url, timeout=self.timeout, ssl=False
-                )
+                future = self.session.delete(url, timeout=self.timeout, ssl=False)
             else:
                 future = self.session.get(url, timeout=self.timeout, ssl=False)
             async with future as resp:


### PR DESCRIPTION
From Home Assistant
```
tests/components/samsungtv/test_init.py::test_setup_updates_from_ssdp
  /home/runner/work/ha-core/ha-core/venv/lib/python3.13/site-packages/aiohttp/client.py:1425:
      DeprecationWarning: verify_ssl is deprecated, use ssl=False instead
    self._resp: _RetType = await self._coro
```

For details see https://github.com/aio-libs/aiohttp/issues/2626