### PR TITLE
Calculate timeout for each request

### DIFF
--- a/samsungtvws/async_rest.py
+++ b/samsungtvws/async_rest.py
@@ -32,21 +32,19 @@ class SamsungTVAsyncRest(connection.SamsungTVWSBaseConnection):
             timeout=timeout,
         )
         self.session = session
-        self._client_timeout = aiohttp.ClientTimeout(timeout)
 
     async def _rest_request(self, target: str, method: str = "GET") -> Dict[str, Any]:
+        timeout = aiohttp.ClientTimeout(self.timeout)
         url = self._format_rest_url(target)
         try:
             if method == "POST":
-                future = self.session.post(url, timeout=self._client_timeout, ssl=False)
+                future = self.session.post(url, timeout=timeout, ssl=False)
             elif method == "PUT":
-                future = self.session.put(url, timeout=self._client_timeout, ssl=False)
+                future = self.session.put(url, timeout=timeout, ssl=False)
             elif method == "DELETE":
-                future = self.session.delete(
-                    url, timeout=self._client_timeout, ssl=False
-                )
+                future = self.session.delete(url, timeout=timeout, ssl=False)
             else:
-                future = self.session.get(url, timeout=self._client_timeout, ssl=False)
+                future = self.session.get(url, timeout=timeout, ssl=False)
             async with future as resp:
                 return helper.process_api_response(await resp.text())
         except aiohttp.ClientConnectionError as err:


### PR DESCRIPTION
The timeout should be calculated for each request in case the instance attribute is changed. Missed that in #153

/CC @epenet