### PR TITLE
Makes import of async-timout library conditional on python version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ requests>=2.21.0
 # async
 websockets>=13
 aiohttp>=3.8.1
-async_timeout>=4.0.3
+async_timeout>=4.0.3; python_version < "3.11"
 
 # encrypted
 cryptography>=35.0.0

--- a/samsungtvws/async_remote.py
+++ b/samsungtvws/async_remote.py
@@ -8,9 +8,13 @@ SPDX-License-Identifier: LGPL-3.0
 
 from asyncio import Future, TimeoutError as AsyncioTimeoutError
 import logging
+import sys
 from typing import Any, Dict, List, Optional, Set
 
-import async_timeout
+if sys.version_info >= (3, 11):
+    from asyncio import timeout
+else:
+    from async_timeout import timeout
 
 from . import async_connection, remote, rest
 from .event import ED_INSTALLED_APP_EVENT, parse_installed_app
@@ -50,7 +54,7 @@ class SamsungTVWSAsyncRemote(async_connection.SamsungTVWSAsyncConnection):
         await self.send_command(remote.ChannelEmitCommand.get_installed_app())
 
         try:
-            async with async_timeout.timeout(self.timeout):
+            async with timeout(self.timeout):
                 response = await app_list_future
         except AsyncioTimeoutError as err:
             _LOGGING.debug("Failed to get app list: %s", err)


### PR DESCRIPTION
The async-timeout has been upstreamed since Python 3.11, thus in the code already. This project supports Python 3.9+ so the library still needs to be imported for backwards compatibility. See https://pypi.org/project/async-timeout/

Fixes issue https://github.com/xchwarze/samsung-tv-ws-api/issues/164