### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
 
-      - name: Install Python 3.9
+      - name: Install Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |
@@ -38,7 +38,6 @@ jobs:
           - { python-version: "3.12", os: ubuntu-latest, session: "tests" }
           - { python-version: "3.11", os: ubuntu-latest, session: "tests" }
           - { python-version: "3.10", os: ubuntu-latest, session: "tests" }
-          - { python-version: "3.9", os: ubuntu-latest, session: "tests" }
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Some advanced topics are covered in dedicated documents:
 
 ## Installation
 
-Requires **Python >= 3.9**.
+Requires **Python >= 3.10**.
 
 ### Install from PyPI (recommended)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = "LGPL-3.0"
 description = "Samsung Smart TV WS API wrapper"
 readme = "README.md"
 authors = [{ name = "Xchwarze" }]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Development Status :: 5 - Production/Stable",
@@ -53,7 +53,7 @@ include = ["samsungtvws*"]
 
 [tool.ruff]
 line-length = 88
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 ignore = [
@@ -85,7 +85,7 @@ combine-as-imports = true
 max-complexity = 18
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 check_untyped_defs = true
 disallow_any_generics = true
 disallow_incomplete_defs = true

--- a/samsungtvws/async_connection.py
+++ b/samsungtvws/async_connection.py
@@ -9,14 +9,13 @@ SPDX-License-Identifier: LGPL-3.0
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 import contextlib
 import json
 import logging
 from types import TracebackType
 from typing import (
     Any,
-    Callable,
 )
 
 from websockets.asyncio.client import ClientConnection, connect

--- a/samsungtvws/connection.py
+++ b/samsungtvws/connection.py
@@ -8,13 +8,14 @@ SPDX-License-Identifier: LGPL-3.0
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import json
 import logging
 import ssl
 import threading
 import time
 from types import TracebackType
-from typing import Any, Callable
+from typing import Any
 
 import websocket
 


### PR DESCRIPTION
Python 3.9 was EOL october 2025: https://devguide.python.org/versions/

Adjust configuration:
- `requires-python` set to `>=3.10`
- `target-version` in `ruff` configuration to `py310`
- `python_version` in `mypy` configuration to `3.10`

Adjust CI:
- Use 3.10 for pre-commit
- Remove tests for 3.9

Adjust documentation:
- Update README

Modernize code:
- Import `Callable` from `collections.abc`