### PR TITLE
Modernise code for Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ include = ["samsungtvws*"]
 
 [tool.ruff]
 line-length = 88
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint]
 ignore = [
@@ -85,7 +85,7 @@ combine-as-imports = true
 max-complexity = 18
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 check_untyped_defs = true
 disallow_any_generics = true
 disallow_incomplete_defs = true

--- a/samsungtvws/art/art.py
+++ b/samsungtvws/art/art.py
@@ -7,12 +7,13 @@ Copyright (C) 2021 Matthew Garrett <mjg59@srcf.ucam.org>
 SPDX-License-Identifier: LGPL-3.0
 """
 
+from collections.abc import Iterable, Sequence
 from datetime import datetime
 import json
 import logging
 import os
 import socket
-from typing import IO, Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union, cast
+from typing import IO, Any, Optional, Union, cast
 import uuid
 
 import websocket
@@ -25,19 +26,19 @@ from ..helper import generate_connection_id, get_ssl_context
 from ..rest import SamsungTVRest
 
 # for typing
-JsonObj = Dict[str, Any]
-WsFrame = Dict[str, Any]
+JsonObj = dict[str, Any]
+WsFrame = dict[str, Any]
 
 _LOGGING = logging.getLogger(__name__)
 ART_ENDPOINT = "com.samsung.art-app"
 
 
 class ArtChannelEmitCommand(SamsungTVCommand):
-    def __init__(self, params: Dict[str, Any]) -> None:
+    def __init__(self, params: dict[str, Any]) -> None:
         super().__init__("ms.channel.emit", params)
 
     @staticmethod
-    def art_app_request(data: Dict[str, Any]) -> "ArtChannelEmitCommand":
+    def art_app_request(data: dict[str, Any]) -> "ArtChannelEmitCommand":
         return ArtChannelEmitCommand(
             {
                 "event": "art_app_request",
@@ -91,7 +92,7 @@ class SamsungTVArt(SamsungTVWSConnection):
     # -------------------------
     # WebSocket primitives
     # -------------------------
-    def _recv_frame(self) -> Tuple[str, WsFrame]:
+    def _recv_frame(self) -> tuple[str, WsFrame]:
         """Receive one websocket frame, process + emit websocket event."""
         assert self.connection
         try:
@@ -154,7 +155,7 @@ class SamsungTVArt(SamsungTVWSConnection):
 
         return sock
 
-    def _recv_d2d_file(self, sock: socket.socket) -> Tuple[str, bytearray, int, int]:
+    def _recv_d2d_file(self, sock: socket.socket) -> tuple[str, bytearray, int, int]:
         """Receive a single D2D file payload."""
         header_len = int.from_bytes(self._recv_exact(sock, 4), "big")
         header = json.loads(self._recv_exact(sock, header_len))
@@ -490,7 +491,7 @@ class SamsungTVArt(SamsungTVWSConnection):
 
     def get_thumbnail_list(
         self, content_id_list: Optional[Union[str, Sequence[str]]] = None
-    ) -> Dict[str, bytearray]:
+    ) -> dict[str, bytearray]:
         """Fetch one or more thumbnails via D2D socket."""
         if content_id_list is None:
             content_id_list = []
@@ -516,7 +517,7 @@ class SamsungTVArt(SamsungTVWSConnection):
         assert payload
         sock = self._open_d2d_socket(self._parse_conn_info(payload))
 
-        thumbnails: Dict[str, bytearray] = {}
+        thumbnails: dict[str, bytearray] = {}
         try:
             total = 1
             current = -1
@@ -533,14 +534,14 @@ class SamsungTVArt(SamsungTVWSConnection):
         self,
         content_id_list: Optional[Union[str, Sequence[str]]] = None,
         as_dict: bool = False,
-    ) -> Union[Dict[str, bytearray], List[bytearray], Optional[bytearray]]:
+    ) -> Union[dict[str, bytearray], list[bytearray], Optional[bytearray]]:
         """Fetch thumbnail(s) via D2D socket."""
         if content_id_list is None:
             content_id_list = []
         if isinstance(content_id_list, str):
             content_id_list = [content_id_list]
 
-        result: Dict[str, bytearray] = {}
+        result: dict[str, bytearray] = {}
 
         for cid in content_id_list:
             d2d_id = self._new_request_uuid()
@@ -685,7 +686,7 @@ class SamsungTVArt(SamsungTVWSConnection):
         if not isinstance(returned, list):
             return False
 
-        return cast(List[object], returned) == cast(List[object], content_id_list)
+        return cast(list[object], returned) == cast(list[object], content_id_list)
 
     def select_image(
         self, content_id: str, category: Optional[str] = None, show: bool = True

--- a/samsungtvws/async_connection.py
+++ b/samsungtvws/async_connection.py
@@ -7,18 +7,15 @@ SPDX-License-Identifier: LGPL-3.0
 """
 
 import asyncio
+from collections.abc import Awaitable, Sequence
 import contextlib
 import json
 import logging
 from types import TracebackType
 from typing import (
     Any,
-    Awaitable,
     Callable,
-    Dict,
-    List,
     Optional,
-    Sequence,
     Union,
 )
 
@@ -61,7 +58,7 @@ class SamsungTVWSAsyncConnection(connection.SamsungTVWSBaseConnection):
         url = self._format_websocket_url(self.endpoint)
 
         _LOGGING.debug("WS url %s", url)
-        connect_kwargs: Dict[str, Any] = {}
+        connect_kwargs: dict[str, Any] = {}
         if self._is_ssl_connection():
             connect_kwargs["ssl"] = get_ssl_context()
         connection = await connect(url, open_timeout=self.timeout, **connect_kwargs)
@@ -129,7 +126,7 @@ class SamsungTVWSAsyncConnection(connection.SamsungTVWSBaseConnection):
 
     async def send_commands(
         self,
-        commands: Sequence[Union[SamsungTVCommand, Dict[str, Any]]],
+        commands: Sequence[Union[SamsungTVCommand, dict[str, Any]]],
         key_press_delay: Optional[float] = None,
     ) -> None:
         if self.connection is None:
@@ -142,7 +139,7 @@ class SamsungTVWSAsyncConnection(connection.SamsungTVWSBaseConnection):
 
     async def send_command(
         self,
-        command: Union[List[SamsungTVCommand], SamsungTVCommand, Dict[str, Any]],
+        command: Union[list[SamsungTVCommand], SamsungTVCommand, dict[str, Any]],
         key_press_delay: Optional[float] = None,
     ) -> None:
         if isinstance(command, list):
@@ -158,7 +155,7 @@ class SamsungTVWSAsyncConnection(connection.SamsungTVWSBaseConnection):
     @staticmethod
     async def _send_command(
         connection: ClientConnection,
-        command: Union[SamsungTVCommand, Dict[str, Any]],
+        command: Union[SamsungTVCommand, dict[str, Any]],
         delay: float,
     ) -> None:
         if isinstance(command, SamsungTVSleepCommand):

--- a/samsungtvws/async_remote.py
+++ b/samsungtvws/async_remote.py
@@ -9,7 +9,7 @@ SPDX-License-Identifier: LGPL-3.0
 from asyncio import Future, TimeoutError as AsyncioTimeoutError
 import logging
 import sys
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Optional
 
 if sys.version_info >= (3, 11):
     from asyncio import timeout
@@ -44,12 +44,12 @@ class SamsungTVWSAsyncRemote(async_connection.SamsungTVWSAsyncConnection):
             name=name,
         )
         self._rest_api: Optional[rest.SamsungTVRest] = None
-        self._app_list_futures: Set[Future[Dict[str, Any]]] = set()
+        self._app_list_futures: set[Future[dict[str, Any]]] = set()
 
-    async def app_list(self) -> Optional[List[Dict[str, Any]]]:
+    async def app_list(self) -> Optional[list[dict[str, Any]]]:
         _LOGGING.debug("Get app list (not available on all TVs)")
         # See https://github.com/xchwarze/samsung-tv-ws-api/issues/23
-        app_list_future: Future[Dict[str, Any]] = Future()
+        app_list_future: Future[dict[str, Any]] = Future()
         self._app_list_futures.add(app_list_future)
         await self.send_command(remote.ChannelEmitCommand.get_installed_app())
 
@@ -61,7 +61,7 @@ class SamsungTVWSAsyncRemote(async_connection.SamsungTVWSAsyncConnection):
             return None
         return parse_installed_app(response)
 
-    def _websocket_event(self, event: str, response: Dict[str, Any]) -> None:
+    def _websocket_event(self, event: str, response: dict[str, Any]) -> None:
         """Handle websocket event."""
         super()._websocket_event(event, response)
         if event == ED_INSTALLED_APP_EVENT:

--- a/samsungtvws/async_rest.py
+++ b/samsungtvws/async_rest.py
@@ -7,7 +7,7 @@ SPDX-License-Identifier: LGPL-3.0
 """
 
 import logging
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Literal, Optional
 
 import aiohttp
 
@@ -37,7 +37,7 @@ class SamsungTVAsyncRest(connection.SamsungTVWSBaseConnection):
 
     async def _rest_request(
         self, method: _REQUEST_METHODS, target: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         timeout = aiohttp.ClientTimeout(self.timeout)
         url = self._format_rest_url(target)
         try:
@@ -49,22 +49,22 @@ class SamsungTVAsyncRest(connection.SamsungTVWSBaseConnection):
                 "TV unreachable or feature not supported on this model."
             ) from err
 
-    async def rest_device_info(self) -> Dict[str, Any]:
+    async def rest_device_info(self) -> dict[str, Any]:
         _LOGGING.debug("Get device info via rest api")
         return await self._rest_request("GET", "")
 
-    async def rest_app_status(self, app_id: str) -> Dict[str, Any]:
+    async def rest_app_status(self, app_id: str) -> dict[str, Any]:
         _LOGGING.debug("Get app %s status via rest api", app_id)
         return await self._rest_request("GET", "applications/" + app_id)
 
-    async def rest_app_run(self, app_id: str) -> Dict[str, Any]:
+    async def rest_app_run(self, app_id: str) -> dict[str, Any]:
         _LOGGING.debug("Run app %s via rest api", app_id)
         return await self._rest_request("POST", "applications/" + app_id)
 
-    async def rest_app_close(self, app_id: str) -> Dict[str, Any]:
+    async def rest_app_close(self, app_id: str) -> dict[str, Any]:
         _LOGGING.debug("Close app %s via rest api", app_id)
         return await self._rest_request("DELETE", "applications/" + app_id)
 
-    async def rest_app_install(self, app_id: str) -> Dict[str, Any]:
+    async def rest_app_install(self, app_id: str) -> dict[str, Any]:
         _LOGGING.debug("Install app %s via rest api", app_id)
         return await self._rest_request("PUT", "applications/" + app_id)

--- a/samsungtvws/cli/art.py
+++ b/samsungtvws/cli/art.py
@@ -53,9 +53,10 @@ def _download_url_to_temp_path(image_url: str) -> tuple[str, str]:
     )
 
     try:
-        with urllib.request.urlopen(request, timeout=60) as response, open(
-            temp_path, "wb"
-        ) as output_file:
+        with (
+            urllib.request.urlopen(request, timeout=60) as response,
+            open(temp_path, "wb") as output_file,
+        ):
             output_file.write(response.read())
     except Exception:
         try:

--- a/samsungtvws/cli/main.py
+++ b/samsungtvws/cli/main.py
@@ -7,7 +7,7 @@ SPDX-License-Identifier: LGPL-3.0
 """
 
 import logging
-from typing import List, Optional
+from typing import Optional
 
 import typer
 from typer.core import TyperGroup
@@ -17,7 +17,7 @@ from samsungtvws import SamsungTVWS
 
 # this helper is for typer to list the commands correctly
 class SortedTyperGroup(TyperGroup):
-    def list_commands(self, ctx: typer.Context) -> List[str]:
+    def list_commands(self, ctx: typer.Context) -> list[str]:
         return sorted(self.commands)
 
 

--- a/samsungtvws/command.py
+++ b/samsungtvws/command.py
@@ -7,15 +7,15 @@ SPDX-License-Identifier: LGPL-3.0
 """
 
 import json
-from typing import Any, Dict
+from typing import Any
 
 
 class SamsungTVCommand:
-    def __init__(self, method: str, params: Dict[str, Any]) -> None:
+    def __init__(self, method: str, params: dict[str, Any]) -> None:
         self.method = method
         self.params = params
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         return {
             "method": self.method,
             "params": self.params,
@@ -30,7 +30,7 @@ class SamsungTVSleepCommand(SamsungTVCommand):
         super().__init__("sleep", {})
         self.delay = delay
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         raise NotImplementedError("Cannot use as_dict on SamsungTVSleepCommand")
 
     def get_payload(self) -> str:

--- a/samsungtvws/connection.py
+++ b/samsungtvws/connection.py
@@ -12,7 +12,7 @@ import ssl
 import threading
 import time
 from types import TracebackType
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 import websocket
 
@@ -104,13 +104,13 @@ class SamsungTVWSBaseConnection:
         else:
             self.token = token
 
-    def _check_for_token(self, response: Dict[str, Any]) -> None:
+    def _check_for_token(self, response: dict[str, Any]) -> None:
         token = response.get("data", {}).get("token")
         if token:
             _LOGGING.debug("Got token %s", token)
             self._set_token(token)
 
-    def _websocket_event(self, event: str, response: Dict[str, Any]) -> None:
+    def _websocket_event(self, event: str, response: dict[str, Any]) -> None:
         """Handle websocket event."""
         if event == MS_ERROR_EVENT:
             _LOGGING.warning("SamsungTVWS websocket error message: %s", response)
@@ -222,7 +222,7 @@ class SamsungTVWSConnection(SamsungTVWSBaseConnection):
 
     def send_command(
         self,
-        command: Union[List[SamsungTVCommand], SamsungTVCommand, Dict[str, Any]],
+        command: Union[list[SamsungTVCommand], SamsungTVCommand, dict[str, Any]],
         key_press_delay: Optional[float] = None,
     ) -> None:
         if self.connection is None:
@@ -240,7 +240,7 @@ class SamsungTVWSConnection(SamsungTVWSBaseConnection):
     @staticmethod
     def _send_command(
         connection: websocket.WebSocket,
-        command: Union[SamsungTVCommand, Dict[str, Any]],
+        command: Union[SamsungTVCommand, dict[str, Any]],
         delay: float,
     ) -> None:
         if isinstance(command, SamsungTVSleepCommand):

--- a/samsungtvws/encrypted/authenticator.py
+++ b/samsungtvws/encrypted/authenticator.py
@@ -4,7 +4,7 @@ import hashlib
 import logging
 import re
 import struct
-from typing import Dict, Optional
+from typing import Optional
 
 import aiohttp
 from cryptography.hazmat.primitives.ciphers import (
@@ -137,7 +137,7 @@ def _apply_samy_go_key_transform(data: bytes) -> bytes:
     return r.encrypt(data)  # type: ignore[no-any-return]
 
 
-def _generate_server_hello(user_id: str, pin: str) -> Dict[str, bytes]:
+def _generate_server_hello(user_id: str, pin: str) -> dict[str, bytes]:
     sha1 = hashlib.sha1()
     sha1.update(pin.encode("utf-8"))
     pin_hash = sha1.digest()
@@ -173,7 +173,7 @@ def _generate_server_hello(user_id: str, pin: str) -> Dict[str, bytes]:
 
 def _parse_client_hello(
     client_hello: str, data_hash: bytes, aes_key: bytes, user_id: str
-) -> Optional[Dict[str, bytes]]:
+) -> Optional[dict[str, bytes]]:
     USER_ID_POS = 15
     USER_ID_LEN_POS = 11
     GX_SIZE = 0x80
@@ -342,7 +342,7 @@ class SamsungTVEncryptedWSAsyncAuthenticator:
         async with self._web_session.get(url) as response:
             LOGGER.debug("Rx: %s", await response.text())
 
-    async def _second_step_of_pairing(self, pin: str) -> Optional[Dict[str, bytes]]:
+    async def _second_step_of_pairing(self, pin: str) -> Optional[dict[str, bytes]]:
         hello_output = _generate_server_hello(self.USER_ID, pin)
         if not hello_output:
             return None

--- a/samsungtvws/encrypted/command.py
+++ b/samsungtvws/encrypted/command.py
@@ -1,15 +1,15 @@
 """SamsungTV Encrypted."""
 
 import json
-from typing import Any, Dict
+from typing import Any
 
 
 class SamsungTVEncryptedCommand:
-    def __init__(self, method: str, body: Dict[str, Any]) -> None:
+    def __init__(self, method: str, body: dict[str, Any]) -> None:
         self.method = method
         self.body = body
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         return {
             "method": self.method,
             "body": self.body,
@@ -20,5 +20,5 @@ class SamsungTVEncryptedCommand:
 
 
 class SamsungTVEncryptedPostCommand(SamsungTVEncryptedCommand):
-    def __init__(self, body: Dict[str, Any]) -> None:
+    def __init__(self, body: dict[str, Any]) -> None:
         super().__init__("POST", body)

--- a/samsungtvws/encrypted/remote.py
+++ b/samsungtvws/encrypted/remote.py
@@ -5,7 +5,7 @@ import contextlib
 import logging
 import time
 from types import TracebackType
-from typing import List, Optional
+from typing import Optional
 
 import aiohttp
 from websockets.asyncio.client import ClientConnection, connect
@@ -147,7 +147,7 @@ class SamsungTVEncryptedWSAsyncRemote:
 
     async def send_commands(
         self,
-        commands: List[SamsungTVEncryptedCommand],
+        commands: list[SamsungTVEncryptedCommand],
         key_press_delay: Optional[float] = None,
     ) -> None:
         assert self._session

--- a/samsungtvws/event.py
+++ b/samsungtvws/event.py
@@ -6,7 +6,7 @@ Copyright (C) 2019 DSR! <xchwarze@gmail.com>
 SPDX-License-Identifier: LGPL-3.0
 """
 
-from typing import Any, Dict, List
+from typing import Any
 
 from .exceptions import MessageError
 
@@ -25,11 +25,11 @@ MS_VOICEAPP_HIDE_EVENT = "ms.voiceApp.hide"
 IGNORE_EVENTS_AT_STARTUP = (ED_EDENTV_UPDATE_EVENT, MS_VOICEAPP_HIDE_EVENT)
 
 
-def parse_installed_app(event: Dict[str, Any]) -> List[Dict[str, Any]]:
+def parse_installed_app(event: dict[str, Any]) -> list[dict[str, Any]]:
     assert event["event"] == ED_INSTALLED_APP_EVENT
     return event["data"]["data"]  # type:ignore[no-any-return]
 
 
-def parse_ms_error(event: Dict[str, Any]) -> MessageError:
+def parse_ms_error(event: dict[str, Any]) -> MessageError:
     assert event["event"] == MS_ERROR_EVENT
     return MessageError(event["data"]["message"])

--- a/samsungtvws/helper.py
+++ b/samsungtvws/helper.py
@@ -11,7 +11,7 @@ import json
 import logging
 import random
 import ssl
-from typing import Any, Dict, Optional, Tuple, Union, cast
+from typing import Any, Optional, Union, cast
 
 from . import exceptions
 
@@ -26,7 +26,7 @@ def serialize_string(string: Union[str, bytes]) -> str:
     return base64.b64encode(string).decode("utf-8")
 
 
-def _split_json_and_tail(buf: bytes) -> Tuple[bytes, bytes]:
+def _split_json_and_tail(buf: bytes) -> tuple[bytes, bytes]:
     """Split WS bytes payload into (json_bytes, tail_bytes)."""
     start = buf.find(b"{")
     if start < 0:
@@ -54,16 +54,16 @@ def _split_json_and_tail(buf: bytes) -> Tuple[bytes, bytes]:
     return json_bytes, tail
 
 
-def process_api_response(response: Union[str, bytes]) -> Dict[str, Any]:
+def process_api_response(response: Union[str, bytes]) -> dict[str, Any]:
     _LOGGING.debug("Processing API response: %s", response)
     try:
         if isinstance(response, str):
-            return cast(Dict[str, Any], json.loads(response))
+            return cast(dict[str, Any], json.loads(response))
 
         # in old ART api
         # bytes: could be pure JSON or JSON + binary tail
         try:
-            return cast(Dict[str, Any], json.loads(response.decode("utf-8")))
+            return cast(dict[str, Any], json.loads(response.decode("utf-8")))
         except (UnicodeDecodeError, json.JSONDecodeError):
             json_bytes, tail = _split_json_and_tail(response)
             frame = json.loads(json_bytes.decode("utf-8"))
@@ -73,7 +73,7 @@ def process_api_response(response: Union[str, bytes]) -> Dict[str, Any]:
                 frame["binary"] = tail
                 frame["binary_len"] = len(tail)
 
-            return cast(Dict[str, Any], frame)
+            return cast(dict[str, Any], frame)
 
     except (UnicodeDecodeError, json.JSONDecodeError) as err:
         raise exceptions.ResponseError(

--- a/samsungtvws/remote.py
+++ b/samsungtvws/remote.py
@@ -8,7 +8,7 @@ SPDX-License-Identifier: LGPL-3.0
 
 import logging
 import time
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 import warnings
 
 from samsungtvws.event import ED_INSTALLED_APP_EVENT, parse_installed_app
@@ -22,12 +22,12 @@ REMOTE_ENDPOINT = "samsung.remote.control"
 
 
 class RemoteControlCommand(SamsungTVCommand):
-    def __init__(self, params: Dict[str, Any]) -> None:
+    def __init__(self, params: dict[str, Any]) -> None:
         super().__init__("ms.remote.control", params)
 
 
 class ChannelEmitCommand(SamsungTVCommand):
-    def __init__(self, params: Dict[str, Any]) -> None:
+    def __init__(self, params: dict[str, Any]) -> None:
         super().__init__("ms.channel.emit", params)
 
     @staticmethod
@@ -93,7 +93,7 @@ class SendRemoteKey(RemoteControlCommand):
         )
 
     @staticmethod
-    def hold(key: str, seconds: float) -> List["SamsungTVCommand"]:
+    def hold(key: str, seconds: float) -> list["SamsungTVCommand"]:
         return [
             SendRemoteKey.press(key),
             SamsungTVSleepCommand(seconds),
@@ -101,7 +101,7 @@ class SendRemoteKey(RemoteControlCommand):
         ]
 
     @staticmethod
-    def hold_key(key: str, seconds: float) -> List["SamsungTVCommand"]:
+    def hold_key(key: str, seconds: float) -> list["SamsungTVCommand"]:
         warnings.warn(
             "SendRemoteKey.hold_key is deprecated, please use SendRemoteKey.hold instead",
             DeprecationWarning,
@@ -238,16 +238,16 @@ class SamsungTVWS(connection.SamsungTVWSConnection):
             name=name,
         )
         self._rest_api: Optional[rest.SamsungTVRest] = None
-        self._app_list: Optional[List[Dict[str, Any]]] = None
+        self._app_list: Optional[list[dict[str, Any]]] = None
 
     def _ws_send(
         self,
-        command: Union[SamsungTVCommand, Dict[str, Any]],
+        command: Union[SamsungTVCommand, dict[str, Any]],
         key_press_delay: Optional[float] = None,
     ) -> None:
         return super().send_command(command, key_press_delay)
 
-    def _websocket_event(self, event: str, response: Dict[str, Any]) -> None:
+    def _websocket_event(self, event: str, response: dict[str, Any]) -> None:
         """Handle websocket event."""
         super()._websocket_event(event, response)
         if event == ED_INSTALLED_APP_EVENT:
@@ -305,7 +305,7 @@ class SamsungTVWS(connection.SamsungTVWSConnection):
         _LOGGING.debug("Opening url in browser %s", url)
         self.run_app("org.tizen.browser", "NATIVE_LAUNCH", url)
 
-    def app_list(self) -> Optional[List[Dict[str, Any]]]:
+    def app_list(self) -> Optional[list[dict[str, Any]]]:
         _LOGGING.debug("Get app list (not available on all TVs)")
         # See https://github.com/xchwarze/samsung-tv-ws-api/issues/23
         self._app_list = None
@@ -331,19 +331,19 @@ class SamsungTVWS(connection.SamsungTVWSConnection):
             self._rest_api = rest.SamsungTVRest(self.host, self.port, self.timeout)
         return self._rest_api
 
-    def rest_device_info(self) -> Dict[str, Any]:
+    def rest_device_info(self) -> dict[str, Any]:
         return self._get_rest_api().rest_device_info()
 
-    def rest_app_status(self, app_id: str) -> Dict[str, Any]:
+    def rest_app_status(self, app_id: str) -> dict[str, Any]:
         return self._get_rest_api().rest_app_status(app_id)
 
-    def rest_app_run(self, app_id: str) -> Dict[str, Any]:
+    def rest_app_run(self, app_id: str) -> dict[str, Any]:
         return self._get_rest_api().rest_app_run(app_id)
 
-    def rest_app_close(self, app_id: str) -> Dict[str, Any]:
+    def rest_app_close(self, app_id: str) -> dict[str, Any]:
         return self._get_rest_api().rest_app_close(app_id)
 
-    def rest_app_install(self, app_id: str) -> Dict[str, Any]:
+    def rest_app_install(self, app_id: str) -> dict[str, Any]:
         return self._get_rest_api().rest_app_install(app_id)
 
     def shortcuts(self) -> shortcuts.SamsungTVShortcuts:

--- a/samsungtvws/rest.py
+++ b/samsungtvws/rest.py
@@ -7,7 +7,7 @@ SPDX-License-Identifier: LGPL-3.0
 """
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import requests
 
@@ -30,7 +30,7 @@ class SamsungTVRest(connection.SamsungTVWSBaseConnection):
             timeout=timeout,
         )
 
-    def _rest_request(self, target: str, method: str = "GET") -> Dict[str, Any]:
+    def _rest_request(self, target: str, method: str = "GET") -> dict[str, Any]:
         url = self._format_rest_url(target)
         try:
             if method == "POST":
@@ -47,22 +47,22 @@ class SamsungTVRest(connection.SamsungTVWSBaseConnection):
                 "TV unreachable or feature not supported on this model."
             ) from err
 
-    def rest_device_info(self) -> Dict[str, Any]:
+    def rest_device_info(self) -> dict[str, Any]:
         _LOGGING.debug("Get device info via rest api")
         return self._rest_request("")
 
-    def rest_app_status(self, app_id: str) -> Dict[str, Any]:
+    def rest_app_status(self, app_id: str) -> dict[str, Any]:
         _LOGGING.debug("Get app %s status via rest api", app_id)
         return self._rest_request("applications/" + app_id)
 
-    def rest_app_run(self, app_id: str) -> Dict[str, Any]:
+    def rest_app_run(self, app_id: str) -> dict[str, Any]:
         _LOGGING.debug("Run app %s via rest api", app_id)
         return self._rest_request("applications/" + app_id, "POST")
 
-    def rest_app_close(self, app_id: str) -> Dict[str, Any]:
+    def rest_app_close(self, app_id: str) -> dict[str, Any]:
         _LOGGING.debug("Close app %s via rest api", app_id)
         return self._rest_request("applications/" + app_id, "DELETE")
 
-    def rest_app_install(self, app_id: str) -> Dict[str, Any]:
+    def rest_app_install(self, app_id: str) -> dict[str, Any]:
         _LOGGING.debug("Install app %s via rest api", app_id)
         return self._rest_request("applications/" + app_id, "PUT")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,9 @@ from websockets.asyncio.client import ClientConnection
 @pytest.fixture(autouse=True)
 def override_time_sleep():
     """Ignore time sleep in tests."""
-    with patch("samsungtvws.connection.time.sleep"), patch(
-        "samsungtvws.remote.time.sleep"
+    with (
+        patch("samsungtvws.connection.time.sleep"),
+        patch("samsungtvws.remote.time.sleep"),
     ):
         yield
 

--- a/tests/test_art.py
+++ b/tests/test_art.py
@@ -24,9 +24,10 @@ _UUID = "07e72228-7110-4655-aaa6-d81b5188c219"
 
 def test_create_connection_from_remote() -> None:
     connection = Mock()
-    with patch("samsungtvws.art.art.uuid.uuid4", return_value=_UUID), patch(
-        "samsungtvws.connection.websocket.create_connection"
-    ) as connection_class:
+    with (
+        patch("samsungtvws.art.art.uuid.uuid4", return_value=_UUID),
+        patch("samsungtvws.connection.websocket.create_connection") as connection_class,
+    ):
         connection_class.return_value = connection
         connection.recv.side_effect = [
             MS_CHANNEL_CONNECT_SAMPLE,
@@ -47,9 +48,10 @@ def test_create_connection_from_remote() -> None:
 
 def test_create_connection_direct() -> None:
     connection = Mock()
-    with patch("samsungtvws.art.art.uuid.uuid4", return_value=_UUID), patch(
-        "samsungtvws.connection.websocket.create_connection"
-    ) as connection_class:
+    with (
+        patch("samsungtvws.art.art.uuid.uuid4", return_value=_UUID),
+        patch("samsungtvws.connection.websocket.create_connection") as connection_class,
+    ):
         connection_class.return_value = connection
         connection.recv.side_effect = [
             MS_CHANNEL_CONNECT_SAMPLE,
@@ -120,8 +122,9 @@ def test_change_matte(connection: Mock) -> None:
 
 def test_send_image_failure(connection: Mock) -> None:
     """Ensure send_image failure raises error and doesn't hang indefinitely."""
-    with patch("samsungtvws.art.art.uuid.uuid4", return_value=_UUID), patch(
-        "samsungtvws.helper.random.randrange", return_value=4091151321
+    with (
+        patch("samsungtvws.art.art.uuid.uuid4", return_value=_UUID),
+        patch("samsungtvws.helper.random.randrange", return_value=4091151321),
     ):
         connection.recv.side_effect = [
             MS_CHANNEL_CONNECT_SAMPLE,
@@ -173,12 +176,14 @@ def test_send_image_success_sends_binary_frame(connection: Mock) -> None:
     file_bytes = b"\x89PNG\r\n\x1a\nFAKEPNGDATA"
 
     sock = Mock()
-    with patch("samsungtvws.art.art.uuid.uuid4", return_value=_UUID), patch(
-        "samsungtvws.helper.random.randrange", return_value=4091151321
-    ), patch.object(
-        SamsungTVArt,
-        "_open_d2d_socket",
-        return_value=sock,
+    with (
+        patch("samsungtvws.art.art.uuid.uuid4", return_value=_UUID),
+        patch("samsungtvws.helper.random.randrange", return_value=4091151321),
+        patch.object(
+            SamsungTVArt,
+            "_open_d2d_socket",
+            return_value=sock,
+        ),
     ):
         # recv order:
         # - connect + ready (open())


### PR DESCRIPTION
Python 3.8 was EOL in October 2024: https://devguide.python.org/versions/

Support for 3.8 was removed in:
- CI/workflow: 5c3484336027dd67d60243efdb059cd52a858b19
- Packaging: #152 / 1f7d6722f6300e5ff46ccaa8adee71f12249ac36
- Readme: f1830b20e6e7cd9dba2a13c13602fa6e2a9c369d

Adjust configuration:
- `target-version` in `ruff` configuration to `py39`
-  `python_version` in `mypy` configuration to `3.9`

Apply fixes:
- Replace `Dict`, `List`, `Set`, `Tuple` with `dict`, `list`, `set`, `tuple`
- Import `Awaitable`, `Iterable`, `Sequence` from `collections.abc`
- Parenthesize multiple context managers
