### PR TITLE
Fix CI on aiohttp 3.14 (aioresponses incompatibility); single-source deps on pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,12 @@ dev = [
     "pytest>=8.3.3",
     "pytest-asyncio>=0.24",
     "aioresponses>=0.7.7",
+    # aioresponses 0.7.9 (its latest release) is incompatible with aiohttp 3.14
+    # (ClientResponse now requires stream_writer), which breaks the test suite.
+    # Cap aiohttp in the dev/test env only; the runtime `async` extra above stays
+    # uncapped, so end users are unaffected. Drop once the fix ships:
+    # https://github.com/pnuckowski/aioresponses/pull/288
+    "aiohttp<3.14",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,24 +1,5 @@
-# sync
-websocket-client>=0.57.0
-requests>=2.21.0
-yarl>=1.9
-
-# async
-websockets>=13
-aiohttp>=3.8.1
-async_timeout>=4.0.3; python_version < "3.11"
-
-# encrypted
-cryptography>=35.0.0
-py3rijndael>=0.3.3
-
-# cli
-typer>=0.20
-wakeonlan>=3.0.0
-
-# dev
-mypy>=1.13
-pre-commit>=3.5
-pytest>=8.3.3
-pytest-asyncio>=0.24
-aioresponses>=0.7.7
+# Dependencies live in pyproject.toml (the single source of truth).
+# This file installs the package with all extras so legacy
+# `pip install -r requirements.txt` workflows (including CI) keep working and
+# pick up the same constraints (e.g. the dev-only aiohttp cap for aioresponses).
+-e .[async,encrypted,cli,dev]


### PR DESCRIPTION
## Problem
CI is currently red on `master` due to a dependency drift, unrelated to any code change here: **`aioresponses` 0.7.9 (its latest release) is incompatible with `aiohttp` 3.14** — aiohttp 3.14 made `ClientResponse.__init__()` require a `stream_writer` argument that aioresponses doesn't pass:

```
TypeError: ClientResponse.__init__() missing 1 required keyword-only argument: 'stream_writer'
```

`requirements.txt` leaves `aiohttp` unpinned, so the test matrix installs 3.14 and `tests/test_encrypted_authenticator.py` errors out on every leg. (The last green run, 2026-05-28, predates aiohttp 3.14.)

## Changes
1. **Cap `aiohttp<3.14` in the `[dev]` extra only.** This unbreaks the test suite while leaving the runtime `async` extra (`aiohttp>=3.8.1`) untouched — end users installing `samsungtvws[async]` are unaffected (verified: an `.[async]`-only install still resolves aiohttp 3.14). Comment points to the upstream fix so the bound can be dropped later: pnuckowski/aioresponses#288.
2. **Reduce `requirements.txt` to a one-line shim** (`-e .[async,encrypted,cli,dev]`) that defers to `pyproject.toml`, removing the duplicated dependency list (a second source of truth prone to drift). `pip install -r requirements.txt` — and therefore `ci.yml` — keeps working unchanged.

## Verification
```
.[async] only                       -> aiohttp 3.14.3   (runtime, uncapped)
.[async,encrypted,cli,dev]          -> aiohttp 3.13.5
pip install -r requirements.txt     -> aiohttp 3.13.5
pytest tests/                       -> 37 passed
pre-commit run --all-files          -> ruff / ruff-format / prettier / yamllint / mypy(--strict)  all Passed
```

## Notes
- `ci.yml` is intentionally **not** modified.
- Happy to split this into two PRs (the `aiohttp` cap alone vs. the `requirements.txt` consolidation) if you'd prefer to take just the CI fix — let me know.
